### PR TITLE
[win32] fixed DllCanUnloadNow

### DIFF
--- a/src/win32/DllMain.cpp
+++ b/src/win32/DllMain.cpp
@@ -118,7 +118,7 @@ BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID /*lpReserved*/)
  */
 STDAPI DllCanUnloadNow(void)
 {
-	return (RP_ComBase_isReferenced() ? S_OK : S_FALSE);
+	return (RP_ComBase_isReferenced() ? S_FALSE : S_OK);
 }
 
 /**


### PR DESCRIPTION
The line said `return (RP_ComBase_isReferenced() ? S_OK : S_FALSE);` thus allowing unloading when there are references, which is the opposite of what actually needed: unloading when there are *no* reference.

 I've seen MSDN example code which does `return g_cDllRef > 0 ? S_FALSE : S_OK;` and `RP_ComBase_isReferenced` is pretty much `g_cDllRef > 0` abstraction, so I'm pretty sure that I'm correct.