### PR TITLE
Added support for other PS1 save formats

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,8 @@
   * MegaDrive: A second ROM Header tab for locked-on ROMs has been added.
     This shows the ROM header information for locked-on ROMs for e.g.
     "Sonic 3 & Knuckles".
+  * PlayStationSave: Save formats other than PSV (\*.mcb, \*.mcx, \*.pda,
+    \*.psx, \*.mcs, \*.ps1, and raw saves) are now supported.
 
 * Bug fixes:
   * (GNOME) The .thumbnailer file was not packaged in the Ubuntu pre-built

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ an example configuration file, which can be placed in `~/.config/rom-properties`
 * Nintendo Game Boy: Plain binary (\*.gb, \*.gbc, \*.sgb)
 * Nintendo Game Boy Advance: Plain binary (\*.gba, \*.agb, \*.mb, \*.srl)
 * Nintendo Virtual Boy: Plain binary (\*.vb)
-* Sony PlayStation: Save files (\*.psv)
+* Sony PlayStation: Save files (\*.psv, \*.mcb, \*.mcx, \*.pda, \*.psx, \*.mcs, \*.ps1)
 * Nintendo amiibo: Plain binary (\*.bin, \*.nfc, \*.nfp)
 * Nintendo Entertainment System: iNES dumps (\*.nes), FDS dumps (\*.fds, \*.qd),
   3DS Virtual Console dumps (\*.tds)

--- a/src/libromdata/PlayStationSave.cpp
+++ b/src/libromdata/PlayStationSave.cpp
@@ -235,7 +235,7 @@ PlayStationSave::PlayStationSave(IRpFile *file)
 	info.header.size = sizeof(header);
 	info.header.pData = header;
 	info.ext = nullptr;	// Not needed for PS1.
-	info.szFile = 0;	// Not needed for PS1.
+	info.szFile = file->size();
 	d->saveType = isRomSupported(&info);
 
 	switch (d->saveType) {
@@ -325,9 +325,13 @@ int PlayStationSave::isRomSupported_static(const DetectInfo *info)
 	}
 	if (info->header.size >= sizeof(PS1_54_Header) + sizeof(PS1_SC_Struct)
 	    && memcmp(header + sizeof(PS1_54_Header), sc_magic, sizeof(sc_magic)) == 0) {
+		// Extra filesize check to prevent false-positives
+		if (info->szFile % 8192 != 54) return -1;
 		return PlayStationSavePrivate::SAVE_TYPE_54;
 	}
 	if (memcmp(header, sc_magic, sizeof(sc_magic)) == 0) {
+		// Extra filesize check to prevent false-positives
+		if (info->szFile % 8192 != 0) return -1;
 		return PlayStationSavePrivate::SAVE_TYPE_RAW;
 	}
 	

--- a/src/libromdata/PlayStationSave.cpp
+++ b/src/libromdata/PlayStationSave.cpp
@@ -71,13 +71,20 @@ class PlayStationSavePrivate : public RomDataPrivate
 			SAVE_TYPE_UNKNOWN = -1,	// Unknown save type.
 
 			SAVE_TYPE_PSV = 0,	// PS1 on PS3 individual save file.
+			SAVE_TYPE_RAW,		// Raw blocks without header information
+			SAVE_TYPE_BLOCK,	// Prefixed by header of the first block (*.mcs, *.ps1)
+			SAVE_TYPE_54		// Prefixed by 54-byte header (*.mcb, *.mcx, *.pda, *.psx)
 		};
 		int saveType;
 
 	public:
-		// Save file header. (PSV format)
-		// NOTE: Must be byteswapped on access.
-		PS1_PSV_Header psvHeader;
+		// Save file header.
+		union {
+			PS1_PSV_Header psvHeader;
+			PS1_Block_Entry blockHeader;
+			PS1_54_Header ps54Header;
+		};
+		PS1_SC_Struct scHeader;
 
 		/**
 		 * Load the save file's icons.
@@ -128,15 +135,14 @@ const rp_image *PlayStationSavePrivate::loadIcon(void)
 		return iconAnimData->frames[0];
 	}
 
-	if (saveType != SAVE_TYPE_PSV) {
-		// Only PSV (PS1 on PS3) is supported right now.
+	if (saveType == SAVE_TYPE_UNKNOWN) {
 		return nullptr;
 	}
 
 	// Determine how many frames need to be decoded.
 	int frames;
 	int delay;	// in PAL frames
-	switch (psvHeader.sc.icon_flag) {
+	switch (scHeader.icon_flag) {
 		case PS1_SC_ICON_NONE:
 		default:
 			// No frames.
@@ -179,8 +185,8 @@ const rp_image *PlayStationSavePrivate::loadIcon(void)
 
 		// Icon format is linear 16x16 4bpp with RGB555 palette.
 		iconAnimData->frames[i] = ImageDecoder::fromPS1_CI4(16, 16,
-			psvHeader.sc.icon_data[i], sizeof(psvHeader.sc.icon_data[i]),
-			psvHeader.sc.icon_pal, sizeof(psvHeader.sc.icon_pal));
+			scHeader.icon_data[i], sizeof(scHeader.icon_data[i]),
+			scHeader.icon_pal, sizeof(scHeader.icon_pal));
 	}
 
 
@@ -237,8 +243,19 @@ PlayStationSave::PlayStationSave(IRpFile *file)
 			// PSV (PS1 on PS3)
 			// Save the header for later.
 			memcpy(&d->psvHeader, header, sizeof(d->psvHeader));
+			memcpy(&d->scHeader, header + sizeof(d->psvHeader), sizeof(d->scHeader));
 			break;
-
+		case PlayStationSavePrivate::SAVE_TYPE_RAW:
+			memcpy(&d->scHeader, header, sizeof(d->scHeader));
+			break;
+		case PlayStationSavePrivate::SAVE_TYPE_BLOCK:
+			memcpy(&d->blockHeader, header, sizeof(d->blockHeader));
+			memcpy(&d->scHeader, header + sizeof(d->blockHeader), sizeof(d->scHeader));
+			break;
+		case PlayStationSavePrivate::SAVE_TYPE_54:
+			memcpy(&d->ps54Header, header, sizeof(d->ps54Header));
+			memcpy(&d->scHeader, header + sizeof(d->ps54Header), sizeof(d->scHeader));
+			break;
 		default:
 			// Unknown save type.
 			d->saveType = PlayStationSavePrivate::SAVE_TYPE_UNKNOWN;
@@ -261,34 +278,50 @@ int PlayStationSave::isRomSupported_static(const DetectInfo *info)
 	assert(info->header.addr == 0);
 	if (!info || !info->header.pData ||
 	    info->header.addr != 0 ||
-	    info->header.size < sizeof(PS1_PSV_Header))
+	    info->header.size < sizeof(PS1_PSV_Header) + sizeof(PS1_SC_Struct)) // FIXME: proper sizeof
 	{
 		// Either no detection information was specified,
 		// or the header is too small.
 		return -1;
 	}
 
-	const PS1_PSV_Header *saveHeader =
-		reinterpret_cast<const PS1_PSV_Header*>(info->header.pData);
-
-	// Check the PSV magic.
-	static const char psv_magic[8] = {
-		0x00, 0x56, 0x53, 0x50, 0x00, 0x00, 0x00, 0x00
-	};
-	if (memcmp(saveHeader->magic, psv_magic, sizeof(psv_magic)) != 0) {
-		// PSV magic is incorrect.
-		return -1;
-	}
+	const uint8_t *header = info->header.pData;
 
 	// Check the SC struct magic.
-	static const char sc_magic[2] = {'S','C'};
-	if (memcmp(saveHeader->sc.magic, sc_magic, sizeof(sc_magic)) != 0) {
-		// SC magic is incorrect.
-		return -1;
-	}
+	static const char sc_magic[2] = { 'S','C' };
+	if (memcmp(header + sizeof(PS1_PSV_Header), sc_magic, sizeof(sc_magic)) == 0) {
+		// Check the PSV magic.
+		static const char psv_magic[8] = {
+			0x00, 0x56, 0x53, 0x50, 0x00, 0x00, 0x00, 0x00
+		};
+		if (memcmp(header, psv_magic, sizeof(psv_magic)) != 0) {
+			// PSV magic is incorrect.
+			return -1;
+		}
 
-	// This is a PSV (PS1 on PS3) save file.
-	return PlayStationSavePrivate::SAVE_TYPE_PSV;
+		// This is a PSV (PS1 on PS3) save file.
+		return PlayStationSavePrivate::SAVE_TYPE_PSV;
+	}
+	if (memcmp(header + sizeof(PS1_Block_Entry), sc_magic, sizeof(sc_magic)) == 0) {
+		// Check the block magic.
+		static const char block_magic[4] = {
+			PS1_ENTRY_ALLOC_FIRST, 0x00, 0x00, 0x00,
+		};
+		if (memcmp(header, block_magic, sizeof(block_magic)) != 0) {
+			// Block magic is incorrect.
+			return -1;
+		}
+
+		return PlayStationSavePrivate::SAVE_TYPE_BLOCK;
+	}
+	if (memcmp(header + sizeof(PS1_54_Header), sc_magic, sizeof(sc_magic)) == 0) {
+		return PlayStationSavePrivate::SAVE_TYPE_54;
+	}
+	if (memcmp(header, sc_magic, sizeof(sc_magic)) == 0) {
+		return PlayStationSavePrivate::SAVE_TYPE_RAW;
+	}
+	
+	return -1;
 }
 
 /**
@@ -338,8 +371,9 @@ const rp_char *const *PlayStationSave::supportedFileExtensions_static(void)
 {
 	static const rp_char *const exts[] = {
 		_RP(".psv"),
-		// TOOD: More formats?
-
+		_RP(".mcb"), _RP(".mcx"), _RP(".pda"), _RP(".psx"),
+		_RP(".mcs"), _RP(".ps1"),
+		// TODO: support RAW? 
 		nullptr
 	};
 	return exts;
@@ -485,15 +519,30 @@ int PlayStationSave::loadFieldData(void)
 
 	// PSV (PS1 on PS3) save file header.
 	const PS1_PSV_Header *psvHeader = &d->psvHeader;
+	const PS1_SC_Struct *scHeader = &d->scHeader;
 	d->fields->reserve(2);	// Maximum of 2 fields.
 
 	// Filename.
-	d->fields->addField_string(_RP("Filename"),
-		cp1252_sjis_to_rp_string(psvHeader->filename, sizeof(psvHeader->filename)));
+	const char* filename = nullptr;
+	switch(d->saveType) {
+	case PlayStationSavePrivate::SAVE_TYPE_PSV:
+		filename = d->psvHeader.filename;
+		break;
+	case PlayStationSavePrivate::SAVE_TYPE_BLOCK:
+		filename = d->blockHeader.filename;
+		break;
+	case PlayStationSavePrivate::SAVE_TYPE_54:
+		filename = d->ps54Header.filename;
+		break;
+	}
+
+	if (filename) {
+		d->fields->addField_string(_RP("Filename"), cp1252_sjis_to_rp_string(filename, 20));
+	}
 
 	// Description.
 	d->fields->addField_string(_RP("Description"),
-		cp1252_sjis_to_rp_string(psvHeader->sc.title, sizeof(psvHeader->sc.title)));
+		cp1252_sjis_to_rp_string(scHeader->title, sizeof(scHeader->title)));
 
 	// TODO: Moar fields.
 

--- a/src/libromdata/PlayStationSave.cpp
+++ b/src/libromdata/PlayStationSave.cpp
@@ -312,6 +312,13 @@ int PlayStationSave::isRomSupported_static(const DetectInfo *info)
 			return -1;
 		}
 
+		// Check the checksum
+		uint8_t checksum = 0;
+		for (int i = 0; i < sizeof(PS1_Block_Entry); i++) {
+			checksum ^= header[i];
+		}
+		if (checksum != 0) return -1;
+
 		return PlayStationSavePrivate::SAVE_TYPE_BLOCK;
 	}
 	if (memcmp(header + sizeof(PS1_54_Header), sc_magic, sizeof(sc_magic)) == 0) {

--- a/src/libromdata/PlayStationSave.cpp
+++ b/src/libromdata/PlayStationSave.cpp
@@ -278,7 +278,7 @@ int PlayStationSave::isRomSupported_static(const DetectInfo *info)
 	assert(info->header.addr == 0);
 	if (!info || !info->header.pData ||
 	    info->header.addr != 0 ||
-	    info->header.size < sizeof(PS1_PSV_Header) + sizeof(PS1_SC_Struct)) // FIXME: proper sizeof
+	    info->header.size < sizeof(PS1_SC_Struct))
 	{
 		// Either no detection information was specified,
 		// or the header is too small.
@@ -289,7 +289,8 @@ int PlayStationSave::isRomSupported_static(const DetectInfo *info)
 
 	// Check the SC struct magic.
 	static const char sc_magic[2] = { 'S','C' };
-	if (memcmp(header + sizeof(PS1_PSV_Header), sc_magic, sizeof(sc_magic)) == 0) {
+	if (info->header.size >= sizeof(PS1_PSV_Header) + sizeof(PS1_SC_Struct)
+	    && memcmp(header + sizeof(PS1_PSV_Header), sc_magic, sizeof(sc_magic)) == 0) {
 		// Check the PSV magic.
 		static const char psv_magic[8] = {
 			0x00, 0x56, 0x53, 0x50, 0x00, 0x00, 0x00, 0x00
@@ -302,7 +303,8 @@ int PlayStationSave::isRomSupported_static(const DetectInfo *info)
 		// This is a PSV (PS1 on PS3) save file.
 		return PlayStationSavePrivate::SAVE_TYPE_PSV;
 	}
-	if (memcmp(header + sizeof(PS1_Block_Entry), sc_magic, sizeof(sc_magic)) == 0) {
+	if (info->header.size >= sizeof(PS1_Block_Entry) + sizeof(PS1_SC_Struct)
+	    && memcmp(header + sizeof(PS1_Block_Entry), sc_magic, sizeof(sc_magic)) == 0) {
 		// Check the block magic.
 		static const char block_magic[4] = {
 			PS1_ENTRY_ALLOC_FIRST, 0x00, 0x00, 0x00,
@@ -321,7 +323,8 @@ int PlayStationSave::isRomSupported_static(const DetectInfo *info)
 
 		return PlayStationSavePrivate::SAVE_TYPE_BLOCK;
 	}
-	if (memcmp(header + sizeof(PS1_54_Header), sc_magic, sizeof(sc_magic)) == 0) {
+	if (info->header.size >= sizeof(PS1_54_Header) + sizeof(PS1_SC_Struct)
+	    && memcmp(header + sizeof(PS1_54_Header), sc_magic, sizeof(sc_magic)) == 0) {
 		return PlayStationSavePrivate::SAVE_TYPE_54;
 	}
 	if (memcmp(header, sc_magic, sizeof(sc_magic)) == 0) {

--- a/src/libromdata/RomDataFactory.cpp
+++ b/src/libromdata/RomDataFactory.cpp
@@ -126,7 +126,6 @@ const RomDataFactoryPrivate::RomDataFns RomDataFactoryPrivate::romDataFns_header
 	GetRomDataFns(N64, false),
 	GetRomDataFns(SNES, false),
 	GetRomDataFns(DreamcastSave, true),
-	GetRomDataFns(PlayStationSave, true),
 	GetRomDataFns(Amiibo, true),
 	GetRomDataFns(NES, false),
 	GetRomDataFns(WiiU, true),
@@ -137,6 +136,7 @@ const RomDataFactoryPrivate::RomDataFns RomDataFactoryPrivate::romDataFns_header
 	// so it should go at the end.
 	// TODO: Thumbnailing on non-Windows platforms.
 	GetRomDataFns(EXE, false),
+	GetRomDataFns(PlayStationSave, true),
 	{nullptr, nullptr, nullptr, false}
 };
 

--- a/src/libromdata/ps1_structs.h
+++ b/src/libromdata/ps1_structs.h
@@ -21,7 +21,7 @@
 
 // References:
 // - http://www.psdevwiki.com/ps3/Game_Saves#Game_Saves_PS1
-// - http://problemkaputt.de/psx-spx.htm
+// - http://problemkaputt.de/psx-spx.htm#memorycarddataformat
 
 #ifndef __ROMPROPERTIES_LIBROMDATA_PS1_STRUCTS_H__
 #define __ROMPROPERTIES_LIBROMDATA_PS1_STRUCTS_H__
@@ -32,6 +32,42 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * 54-byte header used by some standalone saves
+ */
+#pragma pack(1)
+typedef struct PACKED _PS1_54_Header {
+		char filename[21];	// Filename from BlockEntry->filename
+		char title[33];		// Title from SC->title converted to ASCII
+	} PS1_54_Header;
+#pragma pack()
+ASSERT_STRUCT(PS1_54_Header, 54);
+
+typedef enum {
+	PS1_ENTRY_ALLOC_FIRST         = 0x51, // First or only block of a file
+	PS1_ENTRY_ALLOC_MID           = 0x52, // Middle blocks of a file (if 3 or more blocks)
+	PS1_ENTRY_ALLOC_LAST          = 0x53, // Last block of a file (if 2 or more blocks)
+	PS1_ENTRY_ALLOC_FREE          = 0xA0, // Freshly formatted
+	PS1_ENTRY_ALLOC_DELETED_FIRST = 0xA1, // Deleted (first)
+	PS1_ENTRY_ALLOC_DELETED_MID   = 0xA2, // Deleted (middle)
+	PS1_ENTRY_ALLOC_DELETED_LAST  = 0xA3, // Deleted (last)
+} PS1_Entry_Alloc_Flag;
+
+/**
+ * Block Entry. Stored in Block 0 of memorycard. Also used as a header for some standalone saves.
+ */
+#pragma pack(1)
+typedef struct PACKED _PS1_Block_Entry {
+	uint32_t alloc_flag;	// Type 
+	uint32_t filesize;		// Filesize
+	uint16_t next_block;	// Pointer to next block (0xFFFF = EOF)
+	char filename[21];		// BxSxxS-xxxxxyyyyyyyy
+	uint8_t padding[96];
+	uint8_t checksum;
+} PS1_Block_Entry;
+#pragma pack()
+ASSERT_STRUCT(PS1_Block_Entry, 128);
 
 /**
  * "SC" icon display flag.

--- a/src/libromdata/ps1_structs.h
+++ b/src/libromdata/ps1_structs.h
@@ -145,11 +145,9 @@ typedef struct PACKED _PS1_PSV_Header {
 	char filename[20];	// Filename. (filename[6] == 'P' for PocketStation)
 
 	uint8_t reserved4[12];
-
-	PS1_SC_Struct sc;
 } PS1_PSV_Header;
 #pragma pack()
-ASSERT_STRUCT(PS1_PSV_Header, 0x84 + 512);
+ASSERT_STRUCT(PS1_PSV_Header, 0x84);
 
 #ifdef __cplusplus
 }

--- a/src/libromdata/ps1_structs.h
+++ b/src/libromdata/ps1_structs.h
@@ -111,10 +111,9 @@ typedef struct PACKED _PS1_SC_Struct {
 	// PlayStation icon.
 	// NOTE: A palette entry of $0000 is transparent.
 	uint16_t icon_pal[16];		// Icon palette. (RGB555)
-	uint8_t icon_data[3][16*16/2];	// Icon data. (16x16, 4bpp; up to 3 frames)
 } PS1_SC_Struct;
 #pragma pack()
-ASSERT_STRUCT(PS1_SC_Struct, 512);
+ASSERT_STRUCT(PS1_SC_Struct, 128);
 
 /**
  * PSV save format. (PS1 on PS3)


### PR DESCRIPTION
References:
[PSX-SPX: Memory Card Data Format](http://problemkaputt.de/psx-spx.htm#memorycarddataformat)
[MemcardRex](https://github.com/ShendoXT/memcardrex)