### PR TITLE
i18n: Only define ARCH_NAME on Windows

### DIFF
--- a/src/libi18n/i18n.c
+++ b/src/libi18n/i18n.c
@@ -35,6 +35,7 @@
 	((int)(((sizeof(x) / sizeof(x[0]))) / \
 		(size_t)(!(sizeof(x) % sizeof(x[0])))))
 
+#ifdef _WIN32
 // Architecture name.
 #if defined(_M_X64) || defined(__amd64__)
 # define ARCH_NAME L"amd64"
@@ -44,7 +45,6 @@
 # error Unsupported CPU architecture.
 #endif
 
-#ifdef _WIN32
 /**
  * Initialize the internationalization subsystem.
  * (Windows version)


### PR DESCRIPTION
ARCH_NAME is only used on Windows, but will cause compilation to fail on unrecognised architectures, even on non-Windows platforms.