### PR TITLE
MegaDrive: add .68k as an extension

### DIFF
--- a/src/libromdata/Console/MegaDrive.cpp
+++ b/src/libromdata/Console/MegaDrive.cpp
@@ -838,7 +838,7 @@ const char *const *MegaDrive::supportedFileExtensions_static(void)
 	static const char *const exts[] = {
 		".gen", ".smd",
 		".32x", ".pco",
-		".sgd",	// Official extension
+		".sgd",	".68k", // Official extensions
 
 		// NOTE: These extensions may cause conflicts on
 		// Windows if fallback handling isn't working.


### PR DESCRIPTION
As seen in [Sega Classics](https://store.steampowered.com/app/34270/) on Steam.

Proof:
![image](https://user-images.githubusercontent.com/4050457/61760699-0e3c8f80-add5-11e9-99a4-994e0dbbaa78.png)
