### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ button.
 | Microsoft Xbox 360 (STFS) |       Yes      |    Yes   |        No       |       No       |
 | Microsoft Xbox Game Discs |       Yes      |    Yes   |       Icon      |       No       |
 | Nintendo 64               |       Yes      |    Yes   |       N/A       |       No       |
-| iQue N64 .cmd/.dat files  |       Yes      |    Yes   |   Icon, Banner  |       No       |
+| iQue Player ticket files  |       Yes      |    Yes   |   Icon, Banner  |       No       |
 | Nintendo GameCube Discs   |       Yes      |    Yes   |      Banner     |  Disc, Covers  |
 | Nintendo GameCube Banners |       Yes      |    Yes   |      Banner     |       No       |
 | Nintendo GameCube Saves   |       Yes      |    Yes   |       Icon      |       N/A      |


### PR DESCRIPTION
It's called the iQue Player. That's its name. N64 was never anything to do with that. iQue Player is what it is.