### PR TITLE
[libromdata] ISO: Added support for High Sierra Format CDs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
     (Same as Game Boy and Game Boy Color.)
   * NES: Added more (unused) mappers for TNES format.
   * GameCube: Added support for split .wbfs/.wbf1 files.
+  * ISO: Added support for High Sierra Format CDs.
 
 * Bug fixes:
   * WiiWAD: Fix DLC icons no longer working after updating CBCReader to update

--- a/src/libromdata/Other/hsfs_structs.h
+++ b/src/libromdata/Other/hsfs_structs.h
@@ -1,0 +1,146 @@
+/***************************************************************************
+ * ROM Properties Page shell extension. (libromdata)                       *
+ * hsfs_structs.h: High Sierra structs for old CD-ROM images.              *
+ *                                                                         *
+ * Copyright (c) 2020 Egor.                                                *
+ * SPDX-License-Identifier: GPL-2.0-or-later                               *
+ ***************************************************************************/
+
+// Reference: OpenSolaris source code /usr/src/uts/common/sys/fs/hsfs_spec.h
+
+#ifndef __ROMPROPERTIES_LIBROMDATA_HSFS_STRUCTS_H__
+#define __ROMPROPERTIES_LIBROMDATA_HSFS_STRUCTS_H__
+
+#include <stdint.h>
+
+#include "common.h"
+#include "librpcpu/byteorder.h"
+#include "../iso_structs.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#pragma pack(1)
+/**
+ * HSFS Primary Volume Descriptor date/time struct.
+ * Note that the fields are all strings.
+ *
+ * For an unspecified time, all text fields contain '0' (ASCII zero)
+ */
+typedef union PACKED _HSFS_PVD_DateTime_t {
+	char full[16];
+	struct {
+		char year[4];		// Year, from 1 to 9999.
+		char month[2];		// Month, from 1 to 12.
+		char day[2];		// Day, from 1 to 31.
+		char hour[2];		// Hour, from 0 to 23.
+		char minute[2];		// Minute, from 0 to 59.
+		char second[2];		// Second, from 0 to 59.
+		char csecond[2];	// Centiseconds, from 0 to 99.
+	};
+} HSFS_PVD_DateTime_t;
+ASSERT_STRUCT(HSFS_PVD_DateTime_t, 16);
+
+/**
+ * HSFS Directory Entry date/time struct.
+ */
+typedef struct PACKED _HSFS_Dir_DateTime_t {
+	uint8_t year;		// Number of years since 1900.
+	uint8_t month;		// Month, from 1 to 12.
+	uint8_t day;		// Day, from 1 to 31.
+	uint8_t hour;		// Hour, from 0 to 23.
+	uint8_t minute;		// Minute, from 0 to 59.
+	uint8_t second;		// Second, from 0 to 59.
+} HSFS_Dir_DateTime_t;
+ASSERT_STRUCT(HSFS_Dir_DateTime_t, 6);
+
+/**
+ * Directory entry, excluding the variable-length file identifier.
+ */
+typedef struct PACKED _HSFS_DirEntry {
+	uint8_t entry_length;			// Length of Directory Record. (must be at least 33 + filename)
+	uint8_t xattr_length;			// Extended Attribute Record length.
+	uint32_lsb_msb_t block;			// Starting LBA of the file.
+	uint32_lsb_msb_t size;			// Size of the file.
+	HSFS_Dir_DateTime_t mtime;		// Recording date and time.
+	uint8_t flags;				// File flags. (See ISO_File_Flags_t.)
+	uint8_t reserved;
+	uint8_t unit_size;			// File unit size if recorded in interleaved mode; otherwise 0.
+	uint8_t interleave_gap;			// Interleave gap size if recorded in interleaved mode; otherwise 0.
+	uint16_lsb_msb_t volume_seq_num;	// Volume sequence number. (disc this file is recorded on)
+	uint8_t filename_length;		// Filename length. Terminated with ';' followed by the file ID number in ASCII ('1').
+} HSFS_DirEntry;
+ASSERT_STRUCT(HSFS_DirEntry, 33);
+
+/**
+ * Volume descriptor header.
+ */
+typedef struct PACKED _HSFS_Volume_Descriptor_Header {
+	uint32_lsb_msb_t block;	// LBA of this volume descriptor.
+	uint8_t type;		// Volume descriptor type code. (See ISO_Volume_Descriptor_Type.)
+	char identifier[5];	// (strA) "CDROM"
+	uint8_t version;	// Volume descriptor version. (0x01)
+} HSFS_Volume_Descriptor_Header;
+ASSERT_STRUCT(HSFS_Volume_Descriptor_Header, 15);
+
+/**
+ * Primary volume descriptor.
+ *
+ * NOTE: All fields are space-padded. (0x20, ' ')
+ */
+typedef struct PACKED _HSFS_Primary_Volume_Descriptor {
+	HSFS_Volume_Descriptor_Header header;
+
+	uint8_t reserved1;			// [0x00F] 0x00
+	char sysID[32];				// [0x010] (strA) System identifier.
+	char volID[32];				// [0x030] (strD) Volume identifier.
+	uint8_t reserved2[8];			// [0x050] All zeroes.
+	uint32_lsb_msb_t volume_space_size;	// [0x058] Size of volume, in blocks.
+	uint8_t reserved3[32];			// [0x060] All zeroes.
+	uint16_lsb_msb_t volume_set_size;	// [0x080] Size of the logical volume. (number of discs)
+	uint16_lsb_msb_t volume_seq_number;	// [0x084] Disc number in the volume set.
+	uint16_lsb_msb_t logical_block_size;	// [0x088] Logical block size. (usually 2048)
+	uint32_lsb_msb_t path_table_size;	// [0x08C] Path table size, in bytes.
+	uint32_t path_table_lba_L;		// [0x094] (LE32) Path table LBA. (contains LE values only)
+	uint32_t path_table_optional_lba_L[3];	// [0x098] (LE32) Optional path tables LBA. (contain LE values only)
+	uint32_t path_table_lba_M;		// [0x0A4] (BE32) Path table LBA. (contains BE values only)
+	uint32_t path_table_optional_lba_M[3];	// [0x0A8] (BE32) Optional path tables LBA. (contain BE values only)
+	HSFS_DirEntry dir_entry_root;		// [0x0B4] Root directory record
+	char dir_entry_root_filename;		// [0x0D5] Root directory filename. (NULL byte)
+	char volume_set_id[128];		// [0x0D6] (strD) Volume set identifier.
+
+	// For the following fields:
+	// - (???) "\x5F" "FILENAME.BIN" to refer to a file in the root directory.
+	// - If empty, fill with all 0x20.
+	char publisher[128];			// [0x156] (strA) Volume publisher.
+	char data_preparer[128];		// [0x1D6] (strA) Data preparer.
+	char application[128];			// [0x256] (strA) Application.
+
+	// For the following fields:
+	// - Filenames must be in the root directory.
+	// - If empty, fill with all 0x20.
+	char copyright_file[32];		// [0x2D6] (strD) Filename of the copyright file.
+	char abstract_file[32];			// [0x2F6] (strD) Filename of the abstract file.
+
+	// Timestamps.
+	HSFS_PVD_DateTime_t btime;		// [0x316] Volume creation time.
+	HSFS_PVD_DateTime_t mtime;		// [0x326] Volume modification time.
+	HSFS_PVD_DateTime_t exptime;		// [0x336] Volume expiration time.
+	HSFS_PVD_DateTime_t efftime;		// [0x346] Volume effective time.
+
+	uint8_t file_structure_version;		// [0x356] Directory records and path table version. (0x01)
+	uint8_t reserved4[1193];		// [0x357]
+} HSFS_Primary_Volume_Descriptor;
+ASSERT_STRUCT(HSFS_Primary_Volume_Descriptor, ISO_SECTOR_SIZE_MODE1_COOKED);
+
+#define HSFS_VD_MAGIC "CDROM"
+#define HSFS_VD_VERSION 0x01
+
+#pragma pack()
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ROMPROPERTIES_LIBROMDATA_HSFS_STRUCTS_H__ */


### PR DESCRIPTION
[HSF/HSFS](https://en.wikipedia.org/w/index.php?title=High_Sierra_Format). An early version of ISO 9660, used for CD-ROMs mastered between 1985-1988. The actual specifications have been lost to time, and the only thing I found was a bunch of implementations and a couple of articles.

There aren't that many significant differences. Some fields were added, some removed, some changed size, and in the case of the path table, two fields got swapped.

I only implemented HSFS support in `ISO`, but not in `IsoPartition`. We won't need it there anyway.

Here's a (truncated) test file: [hsfshead.iso.gz](https://github.com/GerbilSoft/rom-properties/files/4807372/hsfshead.iso.gz)
(BTW, [that optimization with magic address in RomDataFactory](https://github.com/GerbilSoft/rom-properties/blob/18fcc3fd353b9be45be9b77798920375603a1bb7/src/libromdata/RomDataFactory.cpp#L332) prevents RP from recognizing ISOs smaller than 256K+32B. Would you consider this a bug?)

---
For posterity, here's a function I made that converts HSFS PVD to 9660 PVD:
```c
void
cvtpvd(char *out, char *in)
{
        /* 9660: no LBA */
        memcpy(out+0, in+8, 148);
        /* 9660: no extra LE path tables */
        memcpy(out+148, in+164, 8);
        /* 9660: no extra BE path tables */
        memcpy(out+156, in+180, 578);
        memset(out+734, ' ', 5); /* 9660: longer copyright filename */
        memcpy(out+739, in+758, 32);
        memset(out+771, ' ', 42); /* 9660: longer abstract filename, hsfs: no bibliographic filename */
        /* 9660: dates have timezones */
        memcpy(out+813, in+790, 16);
        out[829] = 0;
        memcpy(out+830, in+806, 16);
        out[846] = 0;
        memcpy(out+847, in+822, 16);
        out[863] = 0;
        memcpy(out+864, in+838, 16);
        out[880] = 0;
        out[881] = in[854];
        memset(out+882, 0, 1166); /* fill the unused space with zeroes */

        memcpy(out+1, "CD001", 5); /* 9660: different magic */
        /* 9660: dirent has timezone */
        out[156+25] = in[156+24];
        out[156+24] = 0;
}
```
And also here's the path table structures (which we don't use).
```cpp
typedef struct PACKED _ISO_PathTable {
        uint8_t filename_length;
        uint8_t xattr_length;
        uint32_t block;
        uint16_t parent;
        // char filename[0];
} ISO_PathTable;
ASSERT_STRUCT(ISO_PathTable, 8);

typedef struct PACKED _HSFS_PathTable {
        uint32_t block;
        uint8_t xattr_length;
        uint8_t filename_length;
        uint16_t parent;
        // char filename[0];
} HSFS_PathTable;
ASSERT_STRUCT(HSFS_PathTable, 8);
```
---
References:
OpenSolaris has the most accurate definition. Looks like it was based on the actual specs.
[/usr/src/uts/common/sys/fs/hsfs_*.h](https://github.com/illumos/illumos-gate/tree/989c147e4f8311ee853a577bac8009cc7ffc4a73/usr/src/uts/common/sys/fs) (in particular see [hsfs_spec.h](https://github.com/illumos/illumos-gate/blob/989c147e4f8311ee853a577bac8009cc7ffc4a73/usr/src/uts/common/sys/fs/hsfs_spec.h) and [hsfs_isospec.h](https://github.com/illumos/illumos-gate/blob/989c147e4f8311ee853a577bac8009cc7ffc4a73/usr/src/uts/common/sys/fs/hsfs_isospec.h))
[/usr/src/uts/common/fs/hsfs/*](https://github.com/illumos/illumos-gate/tree/989c147e4f8311ee853a577bac8009cc7ffc4a73/usr/src/uts/common/fs/hsfs)
FreeBSD's definition ([link](https://github.com/freebsd/freebsd/blob/e97569d20ab13194d7ebc8cd5f1eb49d7c84dcaf/sys/fs/cd9660)) was reverse-engineered from various CDs, according to the commit log. It's uses the same ISO 9660 structs that are also used in Linux and cdrtools.
These two, along with Linux ([1](https://github.com/torvalds/linux/blob/v5.7/include/uapi/linux/iso_fs.h), [2](https://github.com/torvalds/linux/tree/v5.7/fs/isofs)) and DOSBox ([r3886](https://sourceforge.net/p/dosbox/code-0/3886)) are the only implementations I found.

[develop, July 1990 issue, pdf page 24](https://vintageapple.org/develop/pdf/develop-03_9007_July_1990.pdf#page=24)
[Macintosh Technical Notes 209, August 1988](https://tech-insider.org/mac/research/acrobat/8808.pdf)