### PR TITLE
Restore struct packing where necessary

### DIFF
--- a/src/libromdata/Console/gcn_card.h
+++ b/src/libromdata/Console/gcn_card.h
@@ -108,7 +108,8 @@ ASSERT_STRUCT(card_dircntrl, 64);
  * Directory entry.
  * Addresses are relative to the start of the file.
  */
-typedef struct _card_direntry {
+#pragma pack(1)
+typedef struct PACKED _card_direntry {
 	union {
 		struct {
 			char gamecode[4];	// Game code.
@@ -130,6 +131,7 @@ typedef struct _card_direntry {
 	uint16_t pad_01;	// Padding. (0xFFFF)
 	uint32_t commentaddr;	// Comment address.
 } card_direntry;
+#pragma pack()
 ASSERT_STRUCT(card_direntry, 64);
 
 /**

--- a/src/libromdata/Console/gcn_structs.h
+++ b/src/libromdata/Console/gcn_structs.h
@@ -24,7 +24,8 @@ extern "C" {
  */
 #define GCN_MAGIC 0xC2339F3D
 #define WII_MAGIC 0x5D1C9EA3
-typedef struct _GCN_DiscHeader {
+#pragma pack(1)
+typedef struct PACKED _GCN_DiscHeader {
 	union {
 		char id6[6];	// [0x000] Game code. (ID6)
 		struct {
@@ -52,6 +53,7 @@ typedef struct _GCN_DiscHeader {
 
 	uint8_t reserved[2];		// [0x062] Reserved (alignment padding)
 } GCN_DiscHeader;
+#pragma pack()
 ASSERT_STRUCT(GCN_DiscHeader, 100);
 
 /**

--- a/src/libromdata/Console/nes_structs.h
+++ b/src/libromdata/Console/nes_structs.h
@@ -309,11 +309,13 @@ typedef enum {
 /**
  * 3-byte BCD date stamp.
  */
-typedef struct _FDS_BCD_DateStamp {
+#pragma pack(1)
+typedef struct PACKED _FDS_BCD_DateStamp {
 	uint8_t year;	// Add 1925 to this.
 	uint8_t mon;	// 1-12
 	uint8_t mday;	// 1-31
 } FDS_BCD_DateStamp;
+#pragma pack()
 ASSERT_STRUCT(FDS_BCD_DateStamp, 3);
 
 /**

--- a/src/libromdata/Console/ps1_structs.h
+++ b/src/libromdata/Console/ps1_structs.h
@@ -24,10 +24,12 @@ extern "C" {
 /**
  * 54-byte header used by some standalone saves
  */
-typedef struct _PS1_54_Header {
+#pragma pack(1)
+typedef struct PACKED _PS1_54_Header {
 	char filename[21];	// Filename from BlockEntry->filename
 	char title[33];		// Title from SC->title converted to ASCII
 } PS1_54_Header;
+#pragma pack()
 ASSERT_STRUCT(PS1_54_Header, 54);
 
 typedef enum {

--- a/src/libromdata/Console/sega8_structs.h
+++ b/src/libromdata/Console/sega8_structs.h
@@ -71,13 +71,15 @@ typedef enum {
  * NOTE: Fields are in BCD.
  * Reference: http://www.smspower.org/Development/CodemastersHeader
  */
-typedef struct _Sega8_Codemasters_Timestamp {
+#pragma pack(1)
+typedef struct PACKED _Sega8_Codemasters_Timestamp {
 	uint8_t day;
 	uint8_t month;
 	uint8_t year;
 	uint8_t hour;
 	uint8_t minute;
 } Sega8_Codemasters_Timestamp;
+#pragma pack()
 ASSERT_STRUCT(Sega8_Codemasters_Timestamp, 5);
 
 /**
@@ -121,7 +123,8 @@ ASSERT_STRUCT(Sega8_SDSC_Date, 4);
  * Located at $7FE0.
  */
 #define SDSC_MAGIC 'SDSC'
-typedef struct _Sega8_SDSC_RomHeader {
+#pragma pack(1)
+typedef struct PACKED _Sega8_SDSC_RomHeader {
 	uint32_t magic;		// [0x000] 'SDSC'
 	uint8_t version[2];	// [0x004] Program version, in BCD.
 				//         [0] = major version
@@ -134,6 +137,7 @@ typedef struct _Sega8_SDSC_RomHeader {
 	uint16_t name_ptr;	// [0x00C] Program name.
 	uint16_t desc_ptr;	// [0x00E] Program description.
 } Sega8_SDSC_RomHeader;
+#pragma pack()
 ASSERT_STRUCT(Sega8_SDSC_RomHeader, 16);
 
 #ifdef __cplusplus

--- a/src/libromdata/Console/wiiu_structs.h
+++ b/src/libromdata/Console/wiiu_structs.h
@@ -23,7 +23,8 @@ extern "C" {
  * All fields are big-endian.
  * NOTE: Strings are NOT null-terminated!
  */
-typedef struct _WiiU_DiscHeader {
+#pragma pack(1)
+typedef struct PACKED _WiiU_DiscHeader {
 	union {
 		char id[10];		// WUP-P-xxxx
 		struct {
@@ -42,6 +43,7 @@ typedef struct _WiiU_DiscHeader {
 	char hyphen5;
 	char disc_number;	// Disc number, in ASCII. (TODO: Verify?)
 } WiiU_DiscHeader;
+#pragma pack()
 ASSERT_STRUCT(WiiU_DiscHeader, 22);
 
 // Secondary Wii U disc magic at 0x10000.

--- a/src/libromdata/Console/xbox360_xex_structs.h
+++ b/src/libromdata/Console/xbox360_xex_structs.h
@@ -450,7 +450,8 @@ ASSERT_STRUCT(XEX2_Execution_ID, 24);
  * NOTE: This field is supposed to be 10 DWORDs,
  * but only 14 rating regions have been assigned.
  */
-typedef union _XEX2_Game_Ratings {
+#pragma pack(1)
+typedef union PACKED _XEX2_Game_Ratings {
 	uint8_t ratings[14];
 	struct {
 		uint8_t esrb;		// [0x000] See XEX2_Game_Ratings_ESRB_e
@@ -469,6 +470,7 @@ typedef union _XEX2_Game_Ratings {
 		uint8_t singapore;	// [0x00D]
 	};
 } XEX2_Game_Ratings;
+#pragma pack()
 ASSERT_STRUCT(XEX2_Game_Ratings, 14);
 
 /**

--- a/src/libromdata/Handheld/dmg_structs.h
+++ b/src/libromdata/Handheld/dmg_structs.h
@@ -26,7 +26,8 @@ extern "C" {
  * 
  * NOTE: Strings are NOT null-terminated!
  */
-typedef struct _DMG_RomHeader {
+#pragma pack(1)
+typedef struct PACKED _DMG_RomHeader {
 	uint8_t entry[4];
 	uint8_t nintendo[0x30];
 
@@ -64,6 +65,7 @@ typedef struct _DMG_RomHeader {
 	uint8_t header_checksum; // checked by bootrom
 	uint16_t rom_checksum;   // checked by no one
 } DMG_RomHeader;
+#pragma pack()
 ASSERT_STRUCT(DMG_RomHeader, 80);
 
 /**

--- a/src/libromdata/Handheld/gba_structs.h
+++ b/src/libromdata/Handheld/gba_structs.h
@@ -25,7 +25,8 @@ extern "C" {
  *
  * NOTE: Strings are NOT null-terminated!
  */
-typedef struct _GBA_RomHeader {
+#pragma pack(1)
+typedef struct PACKED _GBA_RomHeader {
 	union {
 		uint32_t entry_point;	// 32-bit ARM branch opcode.
 		uint8_t entry_point_bytes[4];
@@ -47,6 +48,7 @@ typedef struct _GBA_RomHeader {
 	uint8_t checksum;
 	uint8_t reserved2[2];
 } GBA_RomHeader;
+#pragma pack()
 ASSERT_STRUCT(GBA_RomHeader, 192);
 
 #ifdef __cplusplus

--- a/src/libromdata/Handheld/gcom_structs.h
+++ b/src/libromdata/Handheld/gcom_structs.h
@@ -38,7 +38,8 @@ extern "C" {
  * NOTE: Strings are NOT null-terminated!
  */
 #define GCOM_SYS_ID "TigerDMGC"
-typedef struct _Gcom_RomHeader {
+#pragma pack(1)
+typedef struct PACKED _Gcom_RomHeader {
 	uint8_t rom_size;		// [0x000] ROM size?
 	uint8_t entry_point_bank;	// [0x001] Entry point: Bank number.
 	uint16_t entry_point;		// [0x002] Entry point.
@@ -65,6 +66,7 @@ typedef struct _Gcom_RomHeader {
 	uint8_t security_code;		// [0x01C] Security code.
 	uint8_t padding[3];		// [0x01D] Padding.
 } Gcom_RomHeader;
+#pragma pack()
 ASSERT_STRUCT(Gcom_RomHeader, 32);
 
 #ifdef __cplusplus

--- a/src/libromdata/Handheld/nds_structs.h
+++ b/src/libromdata/Handheld/nds_structs.h
@@ -25,7 +25,8 @@ extern "C" {
  * All fields are little-endian.
  * NOTE: Strings are NOT null-terminated!
  */
-typedef struct _NDS_RomHeader {
+#pragma pack(1)
+typedef struct PACKED _NDS_RomHeader {
 	char title[12];
 	union {
 		char id6[6];	// Game code. (ID6)
@@ -187,6 +188,7 @@ typedef struct _NDS_RomHeader {
 		uint8_t rsa_sha1[0x80];		// RSA SHA1 signature on 0x000...0xDFF.
 	} dsi;
 } NDS_RomHeader;
+#pragma pack()
 ASSERT_STRUCT(NDS_RomHeader, 4096);
 
 /**

--- a/src/libromdata/Other/hsfs_structs.h
+++ b/src/libromdata/Other/hsfs_structs.h
@@ -44,7 +44,8 @@ ASSERT_STRUCT(HSFS_PVD_DateTime_t, 16);
 /**
  * HSFS Directory Entry date/time struct.
  */
-typedef struct _HSFS_Dir_DateTime_t {
+#pragma pack(1)
+typedef struct PACKED _HSFS_Dir_DateTime_t {
 	uint8_t year;		// Number of years since 1900.
 	uint8_t month;		// Month, from 1 to 12.
 	uint8_t day;		// Day, from 1 to 31.
@@ -52,6 +53,7 @@ typedef struct _HSFS_Dir_DateTime_t {
 	uint8_t minute;		// Minute, from 0 to 59.
 	uint8_t second;		// Second, from 0 to 59.
 } HSFS_Dir_DateTime_t;
+#pragma pack()
 ASSERT_STRUCT(HSFS_Dir_DateTime_t, 6);
 
 /**

--- a/src/libromdata/cdrom_structs.h
+++ b/src/libromdata/cdrom_structs.h
@@ -30,11 +30,13 @@ extern "C" {
  * MSF address.
  * Each value is encoded as BCD.
  */
-typedef struct _CDROM_MSF_t {
+#pragma pack(1)
+typedef struct PACKED _CDROM_MSF_t {
 	uint8_t min;
 	uint8_t sec;	// 60
 	uint8_t frame;	// 75
 } CDROM_MSF_t;
+#pragma pack()
 ASSERT_STRUCT(CDROM_MSF_t, 3);
 
 /**

--- a/src/libromdata/iso_structs.h
+++ b/src/libromdata/iso_structs.h
@@ -85,7 +85,8 @@ ASSERT_STRUCT(uint32_lsb_msb_t, 8);
  * For an unspecified time, all text fields contain '0' (ASCII zero)
  * and tz_offset is binary zero.
  */
-typedef struct _ISO_PVD_DateTime_t {
+#pragma pack(1)
+typedef struct PACKED _ISO_PVD_DateTime_t {
 	union {
 		char full[16];
 		struct {
@@ -103,12 +104,14 @@ typedef struct _ISO_PVD_DateTime_t {
 	// Range: [-48 (GMT-1200), +52 (GMT+1300)]
 	int8_t tz_offset;
 } ISO_PVD_DateTime_t;
+#pragma pack()
 ASSERT_STRUCT(ISO_PVD_DateTime_t, 17);
 
 /**
  * ISO-9660 Directory Entry date/time struct.
  */
-typedef struct _ISO_Dir_DateTime_t {
+#pragma pack(1)
+typedef struct PACKED _ISO_Dir_DateTime_t {
 	uint8_t year;		// Number of years since 1900.
 	uint8_t month;		// Month, from 1 to 12.
 	uint8_t day;		// Day, from 1 to 31.
@@ -120,6 +123,7 @@ typedef struct _ISO_Dir_DateTime_t {
 	// Range: [-48 (GMT-1200), +52 (GMT+1300)]
 	int8_t tz_offset;
 } ISO_Dir_DateTime_t;
+#pragma pack()
 ASSERT_STRUCT(ISO_Dir_DateTime_t, 7);
 
 /**
@@ -154,11 +158,13 @@ typedef enum {
 /**
  * Volume descriptor header.
  */
-typedef struct _ISO_Volume_Descriptor_Header {
+#pragma pack(1)
+typedef struct PACKED _ISO_Volume_Descriptor_Header {
 	uint8_t type;		// Volume descriptor type code. (See ISO_Volume_Descriptor_Type.)
 	char identifier[5];	// (strA) "CD001"
 	uint8_t version;	// Volume descriptor version. (0x01)
 } ISO_Volume_Descriptor_Header;
+#pragma pack()
 ASSERT_STRUCT(ISO_Volume_Descriptor_Header, 7);
 
 /**

--- a/src/librptexture/decoder/ImageDecoder_ETC1.cpp
+++ b/src/librptexture/decoder/ImageDecoder_ETC1.cpp
@@ -20,7 +20,8 @@ namespace LibRpTexture { namespace ImageDecoder {
 // ETC1 block format.
 // NOTE: Layout maps to on-disk format, which is big-endian.
 typedef union _etc1_block {
-	struct {
+#pragma pack(1)
+	struct PACKED {
 		// Base colors
 		// Byte layout:
 		// - diffbit == 0: 4 MSB == base 1, 4 LSB == base 2
@@ -62,6 +63,7 @@ typedef union _etc1_block {
 		uint16_t msb;
 		uint16_t lsb;
 	};
+#pragma pack()
 
 	struct {
 		// Planar mode has 3 colors in RGB676 format.

--- a/src/librptexture/fileformat/pvr3_structs.h
+++ b/src/librptexture/fileformat/pvr3_structs.h
@@ -192,11 +192,13 @@ typedef enum {
 /**
  * PowerVR3 Metadata: Orientation struct.
  */
-typedef struct _PowerVR3_Metadata_Orientation_t {
+#pragma pack(1)
+typedef struct PACKED _PowerVR3_Metadata_Orientation_t {
 	uint8_t x;	// 0 == increases to the right; 1 == increases to the left
 	uint8_t y;	// 0 == increases downwards; 1 == increases upwards
 	uint8_t z;	// 0 == increases inwards; 1 == increases outwards
 } PowerVR3_Metadata_Orientation;
+#pragma pack()
 ASSERT_STRUCT(PowerVR3_Metadata_Orientation, 3);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Some architectures, such as earlier ARM versions, pad structures to ensure alignment, which causes certain static asserts related to structure size to fail.