### PR TITLE
Remove forcing Release build in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,15 +35,6 @@ IF(UNIX AND NOT APPLE)
 		)
 ENDIF(UNIX AND NOT APPLE)
 
-# If no build type is set, default to "Release".
-STRING(TOLOWER "${CMAKE_BUILD_TYPE}" TMP_BUILD_TYPE)
-IF(TMP_BUILD_TYPE STREQUAL "")
-	SET(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
-ELSEIF(TMP_BUILD_TYPE MATCHES "none")
-	SET(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
-ENDIF()
-UNSET(TMP_BUILD_TYPE)
-
 # Put all the binaries and libraries into a single directory.
 # NOTE: CACHE INTERNAL is required in order to get this to work
 # for KF5 for some reason. (and maybe that's why KDE4 did this

--- a/doc/COMPILING.md
+++ b/doc/COMPILING.md
@@ -50,7 +50,7 @@ Clone the repository, then:
 $ cd rom-properties
 $ mkdir build
 $ cd build
-$ cmake .. -DCMAKE_INSTALL_PREFIX=/usr
+$ cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release
 $ make
 $ sudo make install
 (KDE 4.x) $ kbuildsycoca4 --noincremental


### PR DESCRIPTION
Currently the CMake script forces the build type to 'Release' if it's either undefined or set to 'None'. This is [annoying for Arch package maintainers](https://wiki.archlinux.org/title/CMake_package_guidelines#CMake_can_automatically_override_the_default_compiler_optimization_flag) and general users who just want to provide their own compiler flags without CMake interfering.