### PR TITLE
Fix a build error with `CMAKE_BUILD_TYPE=None`

### DIFF
--- a/src/librpbase/RomData.cpp
+++ b/src/librpbase/RomData.cpp
@@ -826,8 +826,10 @@ const rp_image *RomData::image(ImageType imageType) const
 	assert((ret == 0 && img != nullptr) ||
 	       (ret != 0 && img == nullptr));
 
+#ifdef _DEBUG // Must be guarded with this in case neither `_DEBUG` nor `NDEBUG` are defined
 	// SANITY CHECK: `img` must not be -1LL.
 	assert(img != INVALID_IMG_PTR);
+#endif
 
 	return (ret == 0 ? img : nullptr);
 }


### PR DESCRIPTION
The error is caused because neither `_DEBUG` nor `NDEBUG` are defined.