### PR TITLE
Unlist libbsd as a dependency

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,7 +51,7 @@ jobs:
       #if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
-        sudo apt-get install cmake ninja-build libcurl4-openssl-dev zlib1g-dev libpng-dev libjpeg-dev nettle-dev pkg-config libtinyxml2-dev libbsd-dev gettext libseccomp-dev libzstd-dev liblz4-dev liblzo2-dev qtbase5-dev qttools5-dev-tools extra-cmake-modules libkf5kio-dev libkf5widgetsaddons-dev libkf5filemetadata-dev libglib2.0-dev libgtk-3-dev libcairo2-dev libthunarx-3-dev libcanberra-dev libcanberra-gtk3-dev libglib2.0-dev libgtk-3-dev libcairo2-dev libnautilus-extension-dev libcanberra-dev libcanberra-gtk3-dev
+        sudo apt-get install cmake ninja-build libcurl4-openssl-dev zlib1g-dev libpng-dev libjpeg-dev nettle-dev pkg-config libtinyxml2-dev gettext libseccomp-dev libzstd-dev liblz4-dev liblzo2-dev qtbase5-dev qttools5-dev-tools extra-cmake-modules libkf5kio-dev libkf5widgetsaddons-dev libkf5filemetadata-dev libglib2.0-dev libgtk-3-dev libcairo2-dev libthunarx-3-dev libcanberra-dev libcanberra-gtk3-dev libglib2.0-dev libgtk-3-dev libcairo2-dev libnautilus-extension-dev libcanberra-dev libcanberra-gtk3-dev
 
     - name: Build rom-properties (Release build)
       run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ addons:
       - libthunarx-2-dev
       - libgtk-3-dev
       - libnautilus-extension-dev
-      - libbsd-dev
       - gettext
       - libnemo-extension-dev
       - libseccomp-dev

--- a/debian/control
+++ b/debian/control
@@ -30,7 +30,6 @@ Build-Depends:
  libcairo2-dev,
  libnautilus-extension-dev,
  libnemo-extension-dev,
- libbsd-dev,
  gettext,
  liblz4-dev,
  liblzo2-dev,

--- a/doc/COMPILING.md
+++ b/doc/COMPILING.md
@@ -4,7 +4,7 @@
 
 On Debian/Ubuntu, you will need build-essential and the following development
 packages:
-* All: cmake libcurl-dev zlib1g-dev libpng-dev libjpeg-dev nettle-dev pkg-config libtinyxml2-dev libbsd-dev gettext libseccomp-dev
+* All: cmake libcurl-dev zlib1g-dev libpng-dev libjpeg-dev nettle-dev pkg-config libtinyxml2-dev gettext libseccomp-dev
 * Optional decompression: libzstd-dev liblz4-dev liblzo2-dev
 * KDE 4.x: libqt4-dev kdelibs5-dev
 * KDE 5.x: qtbase5-dev qttools5-dev-tools extra-cmake-modules libkf5kio-dev libkf5widgetsaddons-dev libkf5filemetadata-dev
@@ -17,7 +17,7 @@ NOTE: libkf5kio-dev was called kio-dev prior to Ubuntu 18.04.
 On Red Hat, Fedora, OpenSUSE, and other RPM-based distributions, you will need
 to install "C Development Tools and Libraries" and the following development
 packages:
-* All: cmake libcurl-devel zlib-devel libpng16-devel libjpeg-turbo-devel nettle-devel tinyxml2-devel libbsd-devel gettext-tools libseccomp-devel
+* All: cmake libcurl-devel zlib-devel libpng16-devel libjpeg-turbo-devel nettle-devel tinyxml2-devel gettext-tools libseccomp-devel
 * Optional decompression: libzstd-devel lz4-devel lzo-devel
 * KDE 4.x: qt-devel kdelibs-devel
 * KDE 5.x: qt5-qtbase-devel qt5-qttools extra-cmake-modules kf5-kio-devel kf5-kwidgetsaddons-devel kf5-kfilemetadata-devel
@@ -27,7 +27,7 @@ packages:
 
 On Arch and Arch base distros you will need to install "base-devel" and the
 following development packages:
-* All: curl zlib libpng libjpeg-turbo nettle pkgconf tinyxml2 libbsd gettext libseccomp
+* All: curl zlib libpng libjpeg-turbo nettle pkgconf tinyxml2 gettext libseccomp
 * Optional decompression: zstd lz4 lzo
 * KDE 5.x: qt5-base qt5-tools extra-cmake-modules kio kwidgetsaddons kfilemetadata
 * XFCE (GTK+ 3.x): glib2 gtk3 cairo libcanberra


### PR DESCRIPTION
You have minizip-ng's libbsd usage [disabled](https://github.com/GerbilSoft/rom-properties/blob/f2d6b4652d7e801bb50cc07c55ec9a6dbcbac344/extlib/CMakeLists.txt#L167), and my (GTK+ 3) builds don't seem to link it at all, nor do they fail to build without it installed. If it really is unused, then I imagine it's worth removing from the various dependency lists in the repo.

I briefly looked at the commit history related to the libbsd dependency, and it looks like the original reason for its inclusion is no longer the case: the [current logic](https://github.com/GerbilSoft/rom-properties/blob/5c16a08f6cab16625ccf3cf6ce80a4708aa03bdc/extlib/minizip-ng/mz_os_posix.c#L36) for including `bsd/stdlib.h` is very different from how it [used to be](https://github.com/GerbilSoft/rom-properties/blob/21ed4ba5c94fde703422db99416135db787302c6/extlib/minizip/src/mz_os_posix.c#L24) at the time the dependency was first listed in 21ed4ba5c94fde703422db99416135db787302c6.