### PR TITLE
[libromdata] add Lua binary chunk reader

### DIFF
--- a/src/libromdata/CMakeLists.txt
+++ b/src/libromdata/CMakeLists.txt
@@ -84,6 +84,7 @@ SET(${PROJECT_NAME}_SRCS
 	Other/MachO.cpp
 	Other/NintendoBadge.cpp
 	Other/RpTextureWrapper.cpp
+	Other/Lua.cpp
 
 	data/AmiiboData.cpp
 	data/ELFData.cpp
@@ -249,6 +250,7 @@ SET(${PROJECT_NAME}_H
 	Other/MachO.hpp
 	Other/NintendoBadge.hpp
 	Other/RpTextureWrapper.hpp
+	Other/Lua.hpp
 
 	Other/badge_structs.h
 	Other/elf_structs.h

--- a/src/libromdata/Other/Lua.cpp
+++ b/src/libromdata/Other/Lua.cpp
@@ -1,0 +1,623 @@
+/***************************************************************************
+ * ROM Properties Page shell extension. (libromdata)                       *
+ * Lua.cpp: Lua binary chunk reader.                                       *
+ *                                                                         *
+ * Copyright (c) 2016-2020 by David Korth.                                 *
+ * Copyright (c) 2016-2022 by Egor.                                        *
+ * SPDX-License-Identifier: GPL-2.0-or-later                               *
+ ***************************************************************************/
+
+#include "stdafx.h"
+#include "Lua.hpp"
+
+// librpbase, librpfile
+using namespace LibRpBase;
+using LibRpFile::IRpFile;
+
+// C++ STL classes.
+using std::string;
+using std::vector;
+
+namespace LibRomData {
+
+/* Actual header sizes:
+ * 2.4: 11
+ * 2.5: 14
+ * 3.1: 7+Number
+ * 3.2: 6+Number
+ * 4.0: 13+Number
+ * 5.0: 14+Number
+ * 5.1: 12
+ * 5.2: 18
+ * 5.3: 17+Integer+Number (the biggest one)
+ * 5.4: 15+Integer+Number
+ */
+#define LUA_MAGIC "\033Lua"
+#define LUA_TAIL "\x19\x93\r\n\x1a\n"
+#define LUA_HEADERSIZE (17+8+8)
+
+class LuaPrivate final : public RomDataPrivate
+{
+	public:
+		LuaPrivate(Lua *q, IRpFile *file);
+
+	public:
+		/** RomDataInfo **/
+		static const char *const exts[];
+		static const char *const mimeTypes[];
+		static const RomDataInfo romDataInfo;
+
+	private:
+		typedef RomDataPrivate super;
+		RP_DISABLE_COPY(LuaPrivate)
+
+	public:
+		enum class Version {
+			Unknown = -1,
+			Lua2_4 = 0,
+			Lua2_5 = 1,
+			Lua3_1 = 2,
+			Lua3_2 = 3,
+			Lua4_0 = 4,
+			Lua5_0 = 5,
+			Lua5_1 = 6,
+			Lua5_2 = 7,
+			Lua5_3 = 8,
+			Lua5_4 = 9,
+			Max
+		};
+
+		Version version;
+
+		/**
+		 * Converts version byte to Version enum
+		 */
+		static Version to_version(uint8_t version);
+
+	private:
+		/**
+		 * Compares two byte ranges.
+		 * @param lhs buffer to be compared
+		 * @param rhs buffer to compare with
+		 * @param len size of the buffers
+		 * @param endianness when set to 1, one of the buffers is reversed (used for comparing LE number to BE constant)
+		 * @return true if equal
+		 */
+		static bool compare(const uint8_t *lhs, const uint8_t *rhs, size_t len, int endianness);
+
+		/**
+		 * Figures out endianness by comparing an integer with a magic constant
+		 * @param test_int64 int64 big endian representation of magic
+		 * @param p number to check
+		 * @param len length of the number
+		 * @return the endianness
+		 */
+		static int detect_endianness_int(const char *test_int64, const uint8_t *p, size_t len);
+
+		/**
+		 * Figures out endianness and type by comparing a number with a magic constant
+		 * @param test_int64 int64 big endian representation of magic
+		 * @param test_float32 float32 big endian representation of magic
+		 * @param test_float64 float64 big endian representation of magic
+		 * @param p number to check
+		 * @param len length of the number
+		 * @param is_integral (out) whether number is int or float
+		 * @return the endianness
+		 */
+		static int detect_endianness(const char *test_int64, const char *test_float32, const char *test_float64, const uint8_t *p, size_t len, int *is_integral);
+	public:
+		/**
+		 * Parses lua header into individual fields.
+		 */
+		void parse();
+
+	private:
+		/**
+		 * Parses lua 2.x header into individual fields.
+		 */
+		void parse2(uint8_t version, uint8_t *p);
+
+		/**
+		 * Parses lua 3.x header into individual fields.
+		 */
+		void parse3(uint8_t version, uint8_t *p);
+
+		/**
+		 * Parses lua 4.x/5.x header into individual fields.
+		 */
+		void parse4(uint8_t version, uint8_t *p);
+
+	public:
+		// Lua header.
+		uint8_t header[LUA_HEADERSIZE];
+
+		int endianness = -1; // -1 - Unknown, 0 - BE, 1 - LE
+		int int_size = -1; // sizeof(int)
+		int size_t_size = -1; // sizeof(size_t)
+		int Instruction_size = -1; // sizeof(lua_Instruction)
+		bool weird_layout = false; // weird layout of the bits within lua_Instruction
+		int Integer_size = -1; // sizeof(lua_Integer)
+		int Number_size = -1; // sizeof(lua_Number), has a slightly different meaning for 3.x
+		int is_integral = -1; // lua_Number is: -1 - Unknown, 0 - float, 1 - integer, 2 - string (3.2)
+		bool is_float_swapped = false; // float endianness is swapped compared to integer
+		bool corrupted = false; // the LUA_TAIL is corrupted
+};
+
+ROMDATA_IMPL(Lua)
+
+/** LuaPrivate **/
+
+/* RomDataInfo */
+const char *const LuaPrivate::exts[] = {
+	// NOTE: These extensions may cause conflicts on
+	// Windows if fallback handling isn't working.
+	".lua",	// Lua source code.
+	".out", // from luac.out, the default output filename of luac.
+	".lub", // Lua binary
+	// TODO: Others?
+	nullptr
+};
+const char *const LuaPrivate::mimeTypes[] = {
+	// Unofficial MIME types from FreeDesktop.org.
+	// FIXME: these are the MIME types for Lua source code
+	"application/x-lua",
+	"text/x-lua",
+	nullptr
+};
+const RomDataInfo LuaPrivate::romDataInfo = {
+	"Lua", exts, mimeTypes
+};
+
+LuaPrivate::LuaPrivate(Lua *q, IRpFile *file)
+	: super(q, file, &romDataInfo)
+{
+	// Clear the header struct.
+	memset(&header, 0, sizeof(header));
+}
+
+/**
+ * Converts version byte to Version enum
+ */
+LuaPrivate::Version LuaPrivate::to_version(uint8_t version) {
+	switch (version) {
+	// Bytecode dumping was introduced in 2.3, which was never publicly released.
+	// 2.4 kept the same format, so we refer to the 0x23 format as "2.4".
+	case 0x23: return Version::Lua2_4;
+	case 0x25: return Version::Lua2_5; // Also used by 3.0
+	case 0x31: return Version::Lua3_1;
+	case 0x32: return Version::Lua3_2;
+	case 0x40: return Version::Lua4_0;
+	case 0x50: return Version::Lua5_0;
+	case 0x51: return Version::Lua5_1;
+	case 0x52: return Version::Lua5_2;
+	case 0x53: return Version::Lua5_3;
+	case 0x54: return Version::Lua5_4;
+	default:   return Version::Unknown;
+	}
+}
+
+/**
+ * Compares two byte ranges.
+ * @param lhs buffer to be compared
+ * @param rhs buffer to compare with
+ * @param len size of the buffers
+ * @param endianness when set to 1, one of the buffers is reversed (used for comparing LE number to BE constant)
+ * @return true if equal
+ */
+bool LuaPrivate::compare(const uint8_t *lhs, const uint8_t *rhs, size_t len, int endianness)
+{
+	assert(endianness == 0 || endianness == 1);
+	if (endianness == 0) {
+		return !memcmp(lhs, rhs, len);
+	} else if (endianness == 1) {
+		for (size_t i = 0; i < len ; i++)
+			if (lhs[i] != rhs[len-1-i])
+				return false;
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Figures out endianness by comparing an integer with a magic constant
+ * @param test_int64 int64 big endian representation of magic
+ * @param p number to check
+ * @param len length of the number
+ * @return the endianness
+ */
+int LuaPrivate::detect_endianness_int(const char *test_int64, const uint8_t *p, size_t len) {
+	const uint8_t *test_int = nullptr;
+	if (len == 8)
+		test_int = (const uint8_t*)test_int64;
+	else if (len == 4)
+		test_int = (const uint8_t*)test_int64 + 4;
+	else
+		return -1;
+
+	if (compare(p, test_int, len, 0))
+		return 0;
+	else if (compare(p, test_int, len, 1))
+		return 1;
+	else
+		return -1;
+}
+
+/**
+ * Figures out endianness and type by comparing a number with a magic constant
+ * @param test_int64 int64 big endian representation of magic
+ * @param test_float32 float32 big endian representation of magic
+ * @param test_float64 float64 big endian representation of magic
+ * @param p number to check
+ * @param len length of the number
+ * @param is_integral (out) whether number is int or float
+ * @return the endianness
+ */
+int LuaPrivate::detect_endianness(const char *test_int64, const char *test_float32, const char *test_float64, const uint8_t *p, size_t len, int *is_integral) {
+	const uint8_t *test_int = nullptr;
+	const uint8_t *test_float = nullptr;
+	if (len == 8) {
+		test_int = (const uint8_t*)test_int64;
+		test_float = (const uint8_t*)test_float64;
+	} else if (len == 4) {
+		test_int = (const uint8_t*)test_int64 + 4;
+		test_float = (const uint8_t*)test_float32;
+	} else {
+		*is_integral = -1;
+		return -1;
+	}
+	int endianness = -1;
+	if (compare(p, test_float, len, 0))
+		endianness = 0, *is_integral = 1;
+	else if (compare(p, test_float, len, 1))
+		endianness = 1, *is_integral = 1;
+	else if (compare(p, test_int, len, 0))
+		endianness = 0, *is_integral = 1;
+	else if (compare(p, test_int, len, 1))
+		endianness = 1, *is_integral = 1;
+	else
+		endianness = -1, *is_integral = -1;
+	return endianness;
+}
+
+/**
+ * Parses lua header into individual fields.
+ */
+void LuaPrivate::parse()
+{
+	endianness = -1;
+	int_size = -1;
+	size_t_size = -1;
+	Instruction_size = -1;
+	weird_layout = false;
+	Integer_size = -1;
+	Number_size = -1;
+	is_integral = -1;
+	is_float_swapped = false;
+	corrupted = false;
+
+	uint8_t *p = header + 4;
+	uint8_t version = *p++;
+
+	if (version < 0x31)
+		parse2(version, p);
+	else if (version < 0x40)
+		parse3(version, p);
+	else
+		parse4(version, p);
+}
+
+/*
+ * Parses lua 2.x header into individual fields.
+ */
+void LuaPrivate::parse2(uint8_t version, uint8_t *p) {
+	if (version == 0x25) {
+		// these two are hardcoded to be 2 and 4
+		p++; // word size
+		p++; // float size
+		size_t_size = *p++; // pointer size
+	}
+
+	const uint8_t *test_word = (const uint8_t*)"\x12\x34"; // 0x1234
+	if (compare(p, test_word, 2, 0))
+		endianness = 0;
+	else if (compare(p, test_word, 2, 1))
+		endianness = 1;
+
+	const uint8_t *test_float = (const uint8_t*)"\x17\xBF\x0A\x46"; // 0.123456789e-23
+	if (endianness != -1 && compare(p + 2, test_float, 4, !endianness))
+		is_float_swapped = true;
+}
+
+/**
+ * Parses lua 3.x header into individual fields.
+ */
+void LuaPrivate::parse3(uint8_t version, uint8_t *p) {
+	if (version == 0x31) {
+		uint8_t Number_type = *p++;
+		switch (Number_type) {
+			case 'l': Number_size = 4; endianness = 0; is_integral = 1; return;
+			case 'f': Number_size = 4; endianness = 0; is_integral = 0; return;
+			case 'd': Number_size = 8; endianness = 0; is_integral = 0; return;
+			case '?': break;
+			default: return;
+		}
+	}
+
+	Number_size = *p++;
+	if (version == 0x32 && !Number_size) {
+		Number_size = -1;
+		is_integral = 2;
+		return;
+	}
+
+	// This is supposed to be 3.14159265358979323846e8 cast to lua_Number
+	endianness = detect_endianness("\x00\x00\x00\x00\x12\xB9\xB0\xA1", "\x4D\x95\xCD\x85", "\x41\xB2\xB9\xB0\xA1\x5B\xE6\x12",
+		p, Number_size, &is_integral);
+}
+
+/**
+ * Parses lua 4.x/5.x header into individual fields.
+ */
+void LuaPrivate::parse4(uint8_t version, uint8_t *p) {
+	// Format byte. 0 means official format. Apparently it's meant to be used by forks(?)
+	if (version >= 0x51)
+		if (*p++ != 0)
+			return;
+
+	// Some magic bytes for detecting transmission failures. Very similar to PNG magic.
+	// 5.2 had this at the end of the header.
+	if (version >= 0x53) {
+		if (memcmp(p, LUA_TAIL, sizeof(LUA_TAIL)-1)) {
+			corrupted = true;
+			return;
+		}
+		p += sizeof(LUA_TAIL)-1;
+	}
+
+	if (version < 0x53) {
+		endianness = *p > 1 ? -1 : *p;
+		p++;
+	}
+
+	// Lua 5.4 encodes int/size_t as varints, so it doesn't need to know their size.
+	if (version < 0x54) {
+		int_size = *p++;
+		size_t_size = *p++;
+	}
+
+	Instruction_size = *p++;
+
+	if (version == 0x40) {
+		uint8_t INSTRUCTION_bits = *p++;
+		uint8_t OP_bits = *p++;
+		uint8_t B_bits = *p++;
+		if (INSTRUCTION_bits != 32 || OP_bits != 6 || B_bits != 9)
+			weird_layout = true;
+	} else if (version == 0x50) {
+		uint8_t OP_bits = *p++;
+		uint8_t A_bits = *p++;
+		uint8_t B_bits = *p++;
+		uint8_t C_bits = *p++;
+		if (OP_bits != 6 || A_bits != 8 || B_bits != 9 || C_bits != 9)
+			weird_layout = true;
+	}
+
+	// Lua 5.3 introduced support for a separate integer type.
+	if (version >= 0x53)
+		Integer_size = *p++;
+
+	Number_size = *p++;
+	
+	if (version >= 0x53) {
+		// A test number for lua_Integer (0x5678)
+		endianness = detect_endianness_int("\x00\x00\x00\x00\x00\x00\x56\x78", p, Number_size);
+		if (Integer_size != 8 && Integer_size != 4) // a check to avoid overflows
+			return;
+		p += Integer_size;
+		// Note that if this fails, we end up with endianness == -1, and so the test
+		// for lua_Number gets skipped.
+	}
+
+	if (version == 0x51 || version == 0x52) {
+		// Lua 5.1 and 5.2 just have a flag to specify whether lua_Number is int or float.
+		is_integral = *p > 1 ? -1 : *p;
+		p++;
+		// End of header for 5.1
+	} else if (endianness != -1) {
+		// 4.0, 5.0 and 5.3+ have a test number, from which we can tell the format of lua_Number.
+
+		// NOTE: 5.0 and earlier don't compare the fractional part of the test number.
+
+		// Pick the right set of constants based on version
+		int ed = -1;
+		if (version == 0x40) {
+			// This is supposed to be 3.14159265358979323846e8 cast to lua_Number
+			ed = detect_endianness("\x00\x00\x00\x00\x12\xB9\xB0\xA1", "\x4D\x95\xCD\x85", "\x41\xB2\xB9\xB0\xA1\x5B\xE6\x12",
+				p, Number_size, &is_integral);
+		} else if (version == 0x50) {
+			// This is supposed to be 3.14159265358979323846e7 cast to lua_Number
+			ed = detect_endianness("\x00\x00\x00\x00\x01\xDF\x5E\x76", "\x4B\xEF\xAF\x3B", "\x41\x7D\xF5\xE7\x68\x93\x09\xB6",
+				p, Number_size, &is_integral);
+		} else {
+			// This is supposed to be 370.5 cast to lua_Number
+			ed = detect_endianness("\x00\x00\x00\x00\x00\x00\x01\x72", "\x43\xB9\x40\x00", "\x40\x77\x28\x00\x00\x00\x00\x00",
+				p, Number_size, &is_integral);
+		}
+		if (is_integral == 0 && ed != endianness)
+			is_float_swapped = true;
+		// End of header for 4.0, 5.0, 5.3, 5.4
+	}
+
+	if (version == 0x52) {
+		if (memcmp(p, LUA_TAIL, sizeof(LUA_TAIL)-1))
+			corrupted = true;
+		// End of header for 5.2
+	}
+}
+
+/** Lua **/
+
+/**
+ * Read a Lua binary chunk.
+ *
+ * A ROM file must be opened by the caller. The file handle
+ * will be ref()'d and must be kept open in order to load
+ * data from the ROM.
+ *
+ * To close the file, either delete this object or call close().
+ *
+ * NOTE: Check isValid() to determine if this is a valid ROM.
+ *
+ * @param file Open ROM file.
+ */
+Lua::Lua(IRpFile *file)
+	: super(new LuaPrivate(this, file))
+{
+	RP_D(Lua);
+	d->mimeType = "text/x-lua";	// unofficial
+	d->fileType = FileType::Executable; // FIXME: maybe another type should be introduced?
+
+	if (!d->file) {
+		// Could not ref() the file handle.
+		return;
+	}
+
+	// Seek to the beginning of the header.
+	d->file->rewind();
+
+	// Read the ROM header.
+	size_t size = d->file->read(&d->header, sizeof(d->header));
+	if (size != sizeof(d->header)) {
+		UNREF_AND_NULL_NOCHK(d->file);
+		return;
+	}
+
+	// Check if this file is supported.
+	DetectInfo info;
+	info.header.addr = 0;
+	info.header.size = sizeof(d->header);
+	info.header.pData = d->header;
+	info.ext = nullptr;	// Not needed for Lua.
+	info.szFile = 0;	// Not needed for Lua.
+	d->version = static_cast<LuaPrivate::Version>(isRomSupported_static(&info));
+	d->isValid = ((int)d->version >= 0);
+
+	if (!d->isValid) {
+		UNREF_AND_NULL_NOCHK(d->file);
+	}
+}
+
+/** ROM detection functions. **/
+
+/**
+ * Is a ROM image supported by this class?
+ * @param info DetectInfo containing ROM detection information.
+ * @return Class-specific system ID (>= 0) if supported; -1 if not.
+ */
+int Lua::isRomSupported_static(const DetectInfo *info)
+{
+	assert(info != nullptr);
+	assert(info->header.pData != nullptr);
+	if (!info || !info->header.pData ||
+	    info->header.addr != 0 ||
+	    info->header.size < LUA_HEADERSIZE)
+	{
+		return static_cast<int>(LuaPrivate::Version::Unknown);
+	}
+
+	const uint8_t *header = info->header.pData;
+	if (!memcmp(header, LUA_MAGIC, sizeof(LUA_MAGIC)-1)) {
+		uint8_t version = header[4];
+		uint8_t format = version >= 0x51 ? header[5] : 0;
+		if (format == 0)
+			return static_cast<int>(LuaPrivate::to_version(version));
+	}
+		
+	return static_cast<int>(LuaPrivate::Version::Unknown);
+}
+
+/**
+ * Get the name of the system the loaded ROM is designed for.
+ * @return System name, or nullptr if not supported.
+ */
+const char *Lua::systemName(unsigned int type) const
+{
+	RP_D(const Lua);
+	if (!d->isValid || !isSystemNameTypeValid(type))
+		return nullptr;
+
+	static_assert(SYSNAME_TYPE_MASK == 3,
+		"Lua::systemName() array index optimization needs to be updated.");
+	static_assert((int)LuaPrivate::Version::Max == 10,
+		"Lua::systemName() array index optimization needs to be updated.");
+	
+	static const char *const sysNames[10][4] = {
+		{"PUC Lua 2.4", "Lua 2.4", "Lua", nullptr},
+		{"PUC Lua 2.5/3.0", "Lua 2.5/3.0", "Lua", nullptr},
+		{"PUC Lua 3.1", "Lua 3.1", "Lua", nullptr},
+		{"PUC Lua 3.2", "Lua 3.2", "Lua", nullptr},
+		{"PUC Lua 4.0", "Lua 4.0", "Lua", nullptr},
+		{"PUC Lua 5.0", "Lua 5.0", "Lua", nullptr},
+		{"PUC Lua 5.1", "Lua 5.1", "Lua", nullptr},
+		{"PUC Lua 5.2", "Lua 5.2", "Lua", nullptr},
+		{"PUC Lua 5.3", "Lua 5.3", "Lua", nullptr},
+		{"PUC Lua 5.4", "Lua 5.4", "Lua", nullptr},
+	};
+
+	return sysNames[(int)d->version][type & SYSNAME_TYPE_MASK];
+}
+
+/**
+ * Load field data.
+ * Called by RomData::fields() if the field data hasn't been loaded yet.
+ * @return Number of fields read on success; negative POSIX error code on error.
+ */
+int Lua::loadFieldData(void)
+{
+	RP_D(Lua);
+	if (!d->fields->empty()) {
+		// Field data *has* been loaded...
+		return 0;
+	} else if (!d->file || !d->file->isOpen()) {
+		// File isn't open.
+		return -EBADF;
+	} else if (!d->isValid) {
+		// ROM image isn't valid.
+		return -EIO;
+	}
+
+	d->parse();
+
+	d->fields->reserve(10);	// Maximum of 10 fields.
+
+	if (d->endianness != -1)
+		d->fields->addField_string(C_("Lua", "Endianness"),
+			d->endianness ? C_("Lua", "Little-endian") : C_("Lua", "Big-endian"));
+	if (d->int_size != -1)
+		d->fields->addField_string_numeric(C_("Lua", "int size"), d->int_size);
+	if (d->size_t_size != -1)
+		d->fields->addField_string_numeric(C_("Lua", "size_t size"), d->size_t_size);
+	if (d->Instruction_size != -1)
+		d->fields->addField_string_numeric(C_("Lua", "lua_Instruction size"), d->Instruction_size);
+	if (d->Integer_size != -1)
+		d->fields->addField_string_numeric(C_("Lua", "lua_Integer size"), d->Integer_size);
+	if (d->Number_size != -1)
+		d->fields->addField_string_numeric(C_("Lua", "lua_Number size"), d->Number_size);
+	if (d->is_integral != -1)
+		d->fields->addField_string(C_("Lua", "lua_Number type"),
+			d->is_integral == 2 ? C_("Lua", "String") :
+			d->is_integral == 1 ? C_("Lua", "Integer") : C_("Lua", "Floating-point"));
+	if (d->is_float_swapped)
+		d->fields->addField_string(C_("RomData", "Warning"),
+			C_("Lua", "Floating-point values are byte-swapped"), RomFields::STRF_WARNING);
+	if (d->weird_layout)
+		d->fields->addField_string(C_("RomData", "Warning"),
+			C_("Lua", "Unusual instruction layout"), RomFields::STRF_WARNING);
+	if (d->corrupted)
+		d->fields->addField_string(C_("RomData", "Warning"),
+			C_("Lua", "File corrupted"), RomFields::STRF_WARNING);
+
+	return static_cast<int>(d->fields->count());
+}
+
+}

--- a/src/libromdata/Other/Lua.hpp
+++ b/src/libromdata/Other/Lua.hpp
@@ -1,0 +1,22 @@
+/***************************************************************************
+ * ROM Properties Page shell extension. (libromdata)                       *
+ * Lua.hpp: Lua binary chunk reader.                                       *
+ *                                                                         *
+ * Copyright (c) 2016-2018 by David Korth.                                 *
+ * Copyright (c) 2016-2020 by Egor.                                        *
+ * SPDX-License-Identifier: GPL-2.0-or-later                               *
+ ***************************************************************************/
+
+#ifndef __ROMPROPERTIES_LIBROMDATA_LUA_HPP__
+#define __ROMPROPERTIES_LIBROMDATA_LUA_HPP__
+
+#include "librpbase/RomData.hpp"
+
+namespace LibRomData {
+
+ROMDATA_DECL_BEGIN(Lua)
+ROMDATA_DECL_END()
+
+}
+
+#endif /* __ROMPROPERTIES_LIBROMDATA_LUA_HPP__ */

--- a/src/libromdata/Other/lua_structs.h
+++ b/src/libromdata/Other/lua_structs.h
@@ -1,0 +1,183 @@
+/***************************************************************************
+ * ROM Properties Page shell extension. (libromdata)                       *
+ * lua_structs.h: Lua data structures.                                     *
+ *                                                                         *
+ * Copyright (c) 2016-2020 by David Korth.                                 *
+ * Copyright (c) 2016-2022 by Egor.                                        *
+ * SPDX-License-Identifier: GPL-2.0-or-later                               *
+ ***************************************************************************/
+
+/* NOTE: this file is unused, but I left it here for future reference. */
+
+#ifndef __ROMPROPERTIES_LIBROMDATA_LUA_STRUCTS_H__
+#define __ROMPROPERTIES_LIBROMDATA_LUA_STRUCTS_H__
+
+#include <stdint.h>
+#include "common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Lua binary chunk header.
+ *
+ * References:
+ * - lundump.{c,h} from various Lua versions.
+ */
+typedef struct _Lua_Header {
+	char magic[4]; /* '\033Lua' */
+	uint8_t version; /* 0x50 = 5.0, 0x51 = 5.1, etc */
+} Lua_Header;
+ASSERT_STRUCT(Lua_Header, 5);
+
+#define LUA_MAGIC "\033Lua"
+#define LUA_TAIL "\x19\x93\r\n\x1a\n"
+
+/**
+ * Lua 2.3 binary chunk header.
+ */
+typedef struct _Lua2_3_Header {
+	Lua_Header header;
+	/* followed by a test number, which is 0x1234 cast to word */
+	/* followed by a test number, which is 0.123456789e-23 cast to float */
+} Lua2_3_Header;
+ASSERT_STRUCT(Lua2_3_Header, 5);
+
+/**
+ * Lua 2.5 binary chunk header.
+ */
+typedef struct _Lua2_5_Header {
+	Lua_Header header;
+	uint8_t word_size; // hardcoded to 2
+	uint8_t float_size; // hardcoded to 4
+	uint8_t ptr_size;
+	/* followed by a test number, which is 0x1234 cast to word */
+	/* followed by a test number, which is 0.123456789e-23 cast to float */
+} Lua2_5_Header;
+ASSERT_STRUCT(Lua2_5_Header, 8);
+
+/**
+ * Lua 3.1 binary chunk header.
+ */
+typedef struct _Lua3_1_Header {
+	Lua_Header header;
+	uint8_t Number_type; /* 'l' long BE 32, 'f' float BE 32, 'd' double BE 64, '?' native */
+	uint8_t Number_size; /* this is the size of the *native* number type */
+	/* followed by a test number, which is 3.14159265358979323846E8 cast to lua_Number */
+} Lua3_1_Header;
+ASSERT_STRUCT(Lua3_1_Header, 7);
+
+/**
+ * Lua 3.2 binary chunk header.
+ */
+typedef struct _Lua3_2_Header {
+	Lua_Header header;
+	uint8_t Number_size; /* if 0, the numbers are stored as strings, and the test number doesn't exist */
+	/* followed by a test number, which is 3.14159265358979323846E8 cast to lua_Number */
+} Lua3_2_Header;
+ASSERT_STRUCT(Lua3_2_Header, 6);
+
+/**
+ * Lua 4.0 binary chunk header.
+ */
+typedef struct _Lua4_0_Header {
+	Lua_Header header;
+	uint8_t endianness; /* 0 = BE, 1 = LE */
+	uint8_t int_size;
+	uint8_t size_t_size;
+	uint8_t Instruction_size;
+	uint8_t INSTRUCTION_bits;
+	uint8_t OP_bits;
+	uint8_t B_bits;
+	uint8_t Number_size;
+	/* followed by a test number, which is 3.14159265358979323846E8 cast to lua_Number */
+} Lua4_0_Header;
+ASSERT_STRUCT(Lua4_0_Header, 13);
+
+/**
+ * Lua 5.0 binary chunk header.
+ */
+typedef struct _Lua5_0_Header {
+	Lua_Header header;
+	uint8_t endianness; /* 0 = BE, 1 = LE */
+	uint8_t int_size;
+	uint8_t size_t_size;
+	uint8_t Instruction_size;
+	uint8_t OP_bits;
+	uint8_t A_bits;
+	uint8_t B_bits;
+	uint8_t C_bits;
+	uint8_t Number_size;
+	/* followed by a test number, which is 3.14159265358979323846E7 cast to lua_Number */
+} Lua5_0_Header;
+ASSERT_STRUCT(Lua5_0_Header, 14);
+
+/**
+ * Lua 5.1 binary chunk header.
+ */
+typedef struct _Lua5_1_Header {
+	Lua_Header header;
+	uint8_t format; /* 0 = official format */
+	uint8_t endianness; /* 0 = BE, 1 = LE */
+	uint8_t int_size;
+	uint8_t size_t_size;
+	uint8_t Instruction_size;
+	uint8_t Number_size;
+	uint8_t is_integral;
+} Lua5_1_Header;
+ASSERT_STRUCT(Lua5_1_Header, 12);
+
+/**
+ * Lua 5.2 binary chunk header.
+ */
+typedef struct _Lua5_2_Header {
+	Lua_Header header;
+	uint8_t format; /* 0 = official format */
+	uint8_t endianness; /* 0 = BE, 1 = LE */
+	uint8_t int_size;
+	uint8_t size_t_size;
+	uint8_t Instruction_size;
+	uint8_t Number_size;
+	uint8_t is_integral;
+	char tail[6]; /* LUA_TAIL */
+} Lua5_2_Header;
+ASSERT_STRUCT(Lua5_2_Header, 18);
+
+/**
+ * Lua 5.3 binary chunk header.
+ */
+typedef struct _Lua5_3_Header {
+	Lua_Header header;
+	uint8_t format; /* 0 = official format */
+	char tail[6]; /* LUA_TAIL */
+	uint8_t int_size;
+	uint8_t size_t_size;
+	uint8_t Instruction_size;
+	uint8_t Integer_size;
+	uint8_t Number_size;
+	/* followed by test integer 0x5678 */
+	/* followed by test number 370.5 */
+} Lua5_3_Header;
+ASSERT_STRUCT(Lua5_3_Header, 17);
+
+/**
+ * Lua 5.4 binary chunk header.
+ */
+typedef struct _Lua5_4_Header {
+	Lua_Header header;
+	uint8_t format; /* 0 = official format */
+	char tail[6]; /* LUA_TAIL */
+	uint8_t Instruction_size;
+	uint8_t Integer_size;
+	uint8_t Number_size;
+	/* followed by test integer 0x5678 */
+	/* followed by test number 370.5 */
+} Lua5_4_Header;
+ASSERT_STRUCT(Lua5_4_Header, 15);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ROMPROPERTIES_LIBROMDATA_LUA_STRUCTS_H__ */

--- a/src/libromdata/RomDataFactory.cpp
+++ b/src/libromdata/RomDataFactory.cpp
@@ -100,6 +100,7 @@ using std::vector;
 #include "Other/MachO.hpp"
 #include "Other/NintendoBadge.hpp"
 #include "Other/RpTextureWrapper.hpp"
+#include "Other/Lua.hpp"
 
 // Special case for Dreamcast save files.
 #include "Console/dc_structs.h"
@@ -281,6 +282,7 @@ const RomDataFactoryPrivate::RomDataFns RomDataFactoryPrivate::romDataFns_magic[
 
 	// Other
 	GetRomDataFns_addr(ELF, ATTR_NONE, 0, 0x7F454C46),		// '\177ELF'
+	GetRomDataFns_addr(Lua, ATTR_NONE, 0, 0x1B4C7561),		// '\033Lua'
 
 	// Consoles: Xbox 360 STFS
 	// Moved here to prevent conflicts with the Nintendo DS ROM image


### PR DESCRIPTION
an old branch of mine from 2020

for individual commits see: https://github.com/GerbilSoft/rom-properties/compare/master...DankRank:lua
fixes i had to do to get it up-to-date after rebase: https://github.com/GerbilSoft/rom-properties/commit/63abead651761f50d8e1f045b199b4ec7e4c6fa1

lua source for reference: https://www.lua.org/ftp/

notes:
- "binary chunk" is lua-ese for bytecode files. They can be created with the luac tool included in the lua distribution.
- the point of this being in rom-properties is to be able to view various values in the header which affect cross-platform compatibility of these files. Lua itself is very portable, but the binary format is tied to the platform for which the interpreter was compiled.
- lua_structs.h is completely unused. Very early on I realized that doing it by overlaying a struct would be very annoying. Lua team managed to change the header every release, but it's almost always small incremental changes. It's makes more sense to just have a function that that just reads the fields linearly and changes behavior depending on the version. I left lua_structs.h in for future reference, but feel free to delete it.
- Lua devs change their approach to portability very often:
  - 2.x: detects endianness and does byte swaps automatically, but only supports float as the number type. And for whatever reason 2.5 checks pointer size (don't think it's used anywhere).
  - 3.x: depending on the compile options either uses some portable representation (BE float, or even strings), or just native representation with no portability.
  - 4.0 and 5.0: store endianness in the header and use it to enable byte swapping.
  - 5.1, 5.2, 5.3: doesn't even try loading chunks from other platforms. if the header doesn't match, it doesn't load a chunk
  - 5.4: same as above, but they switched to storing internal ints as varints, meaning there are less moving parts now (in particular, size_t doesn't matter anymore, so there's compatibility across 32/64 bit)
  - As you can see, over time they stopped bothering to try to support chunks from other platforms. 
- One of the extensions is ".lua". You see, lua's load function loads both text and binary chunks (by default), so you can replace a lua source file with a binary file and it's would work. So this extension conflict is somewhat justified.
- I haven't done much research into extensions, so the list could probably be expanded. The luac tool just outputs `luac.out` by default, so everyone in the lua community comes up with their own extension. I got `.lub` from Team17 games.
- I forgot to update the changelog/readme/references list, lol.

Example files (one per version. I haven't bothered with more thorough testing)
```sh
xxd -r >2.4.lub <<EOF
00000000: 1b4c 7561 2334 1246 0abf 1746 0000 0a00  .Lua#4.F...F....
00000010: 0000 0a00 696e 7075 742e 6c75 6100 1400  ....input.lua...
00000020: 0007 0000 3f01 0040 5601 0006 0070 7269  ....?..@V....pri
00000030: 6e74 0053 0400 0e00 4865 6c6c 6f2c 2057  nt.S....Hello, W
00000040: 6f72 6c64 2100                           orld!.
EOF
xxd -r >2.5.lub <<EOF
00000000: 1b4c 7561 2502 0408 3412 460a bf17 4600  .Lua%...4.F...F.
00000010: 000a 0000 000a 0069 6e70 7574 2e6c 7561  .......input.lua
00000020: 0014 0000 0700 003f 0100 4056 0100 0600  .......?..@V....
00000030: 7072 696e 7400 5304 000e 0048 656c 6c6f  print.S....Hello
00000040: 2c20 576f 726c 6421 00                   , World!.
EOF
xxd -r >3.1.lub <<EOF
00000000: 1b4c 7561 3164 0800 0000 02a1 5be6 1200  .Lua1d......[...
00000010: 0000 0a69 6e70 7574 2e6c 7561 0000 0000  ...input.lua....
00000020: 0702 001f 0a78 0100 0000 0002 0200 0670  .....x.........p
00000030: 7269 6e74 0002 000e 4865 6c6c 6f2c 2057  rint....Hello, W
00000040: 6f72 6c64 2100                           orld!.
EOF
xxd -r >3.2.lub <<EOF
00000000: 1b4c 7561 3200 0000 0000 0000 000b 4069  .Lua2.........@i
00000010: 6e70 7574 2e6c 7561 0000 0000 0a02 000f  nput.lua........
00000020: 000b 0102 0001 0000 0000 0000 0000 0202  ................
00000030: 0000 0006 7072 696e 7400 0200 0000 0e48  ....print......H
00000040: 656c 6c6f 2c20 576f 726c 6421 00         ello, World!.
EOF
xxd -r >4.0.lub <<EOF
00000000: 1b4c 7561 4001 0408 0820 0609 0812 e65b  .Lua@.... .....[
00000010: a1b0 b9b2 410b 0000 0000 0000 0040 696e  ....A........@in
00000020: 7075 742e 6c75 6100 0000 0000 0000 0000  put.lua.........
00000030: 0002 0000 0000 0000 0002 0000 0000 0000  ................
00000040: 00fd ffff 7f02 0000 0006 0000 0000 0000  ................
00000050: 0070 7269 6e74 000e 0000 0000 0000 0048  .print.........H
00000060: 656c 6c6f 2c20 576f 726c 6421 0000 0000  ello, World!....
00000070: 0000 0000 0004 0000 000c 0000 0000 0000  ................
00000080: 0047 0000 0000 0000 0002 0000 0000 0000  .G..............
00000090: 0000 0000 0000 0000 00                   .........
EOF
xxd -r >5.0.lub <<EOF
00000000: 1b4c 7561 5001 0408 0806 0809 0908 b609  .LuaP...........
00000010: 9368 e7f5 7d41 0b00 0000 0000 0000 4069  .h..}A........@i
00000020: 6e70 7574 2e6c 7561 0000 0000 0000 0000  nput.lua........
00000030: 0204 0000 0001 0000 0001 0000 0001 0000  ................
00000040: 0001 0000 0000 0000 0000 0000 0002 0000  ................
00000050: 0004 0600 0000 0000 0000 7072 696e 7400  ..........print.
00000060: 040e 0000 0000 0000 0048 656c 6c6f 2c20  .........Hello, 
00000070: 576f 726c 6421 0000 0000 0004 0000 0005  World!..........
00000080: 0000 0000 0000 0041 0000 0100 0000 0059  .......A.......Y
00000090: 0001 0000 0000 001b 8000 0000 0000 00    ...............
EOF
xxd -r >5.1.lub <<EOF
00000000: 1b4c 7561 5100 0104 0804 0800 0b00 0000  .LuaQ...........
00000010: 0000 0000 4069 6e70 7574 2e6c 7561 0000  ....@input.lua..
00000020: 0000 0000 0000 0000 0002 0204 0000 0005  ................
00000030: 0000 0041 4000 001c 4000 011e 0080 0002  ...A@...@.......
00000040: 0000 0004 0600 0000 0000 0000 7072 696e  ............prin
00000050: 7400 040e 0000 0000 0000 0048 656c 6c6f  t..........Hello
00000060: 2c20 576f 726c 6421 0000 0000 0004 0000  , World!........
00000070: 0001 0000 0001 0000 0001 0000 0001 0000  ................
00000080: 0000 0000 0000 0000 00                   .........
EOF
xxd -r >5.2.lub <<EOF
00000000: 1b4c 7561 5200 0104 0804 0800 1993 0d0a  .LuaR...........
00000010: 1a0a 0000 0000 0000 0000 0001 0204 0000  ................
00000020: 0006 0040 0041 4000 001d 4000 011f 0080  ...@.A@...@.....
00000030: 0002 0000 0004 0600 0000 0000 0000 7072  ..............pr
00000040: 696e 7400 040e 0000 0000 0000 0048 656c  int..........Hel
00000050: 6c6f 2c20 576f 726c 6421 0000 0000 0001  lo, World!......
00000060: 0000 0001 000b 0000 0000 0000 0040 696e  .............@in
00000070: 7075 742e 6c75 6100 0400 0000 0100 0000  put.lua.........
00000080: 0100 0000 0100 0000 0100 0000 0000 0000  ................
00000090: 0100 0000 0500 0000 0000 0000 5f45 4e56  ............_ENV
000000a0: 00                                       .
EOF
xxd -r >5.3.lub <<EOF
00000000: 1b4c 7561 5300 1993 0d0a 1a0a 0408 0408  .LuaS...........
00000010: 0878 5600 0000 0000 0000 0000 0000 2877  .xV...........(w
00000020: 4001 0b40 696e 7075 742e 6c75 6100 0000  @..@input.lua...
00000030: 0000 0000 0000 0102 0400 0000 0600 4000  ..............@.
00000040: 4140 0000 2440 0001 2600 8000 0200 0000  A@..$@..&.......
00000050: 0406 7072 696e 7404 0e48 656c 6c6f 2c20  ..print..Hello, 
00000060: 576f 726c 6421 0100 0000 0100 0000 0000  World!..........
00000070: 0400 0000 0100 0000 0100 0000 0100 0000  ................
00000080: 0100 0000 0000 0000 0100 0000 055f 454e  ............._EN
00000090: 56                                       V
EOF
xxd -r >5.4.lub <<EOF
00000000: 1b4c 7561 5400 1993 0d0a 1a0a 0408 0878  .LuaT..........x
00000010: 5600 0000 0000 0000 0000 0000 2877 4001  V...........(w@.
00000020: 8b40 696e 7075 742e 6c75 6180 8000 0102  .@input.lua.....
00000030: 8551 0000 000b 0000 0083 8000 0044 0002  .Q...........D..
00000040: 0146 0001 0182 0486 7072 696e 7404 8e48  .F......print..H
00000050: 656c 6c6f 2c20 576f 726c 6421 8101 0000  ello, World!....
00000060: 8085 0100 0000 0080 8081 855f 454e 56    ..........._ENV
EOF
```

Example output:
```
== Reading file '/home/egor/lua/luac/2.4.lub'...
-- PUC Lua 2.4 Executable detected
Endianness: 'Little-endian'

== Reading file '/home/egor/lua/luac/2.5.lub'...
-- PUC Lua 2.5/3.0 Executable detected
Endianness:  'Little-endian'
size_t size: '8'

== Reading file '/home/egor/lua/luac/3.1.lub'...
-- PUC Lua 3.1 Executable detected
Endianness:      'Big-endian'
lua_Number size: '8'
lua_Number type: 'Floating-point'

== Reading file '/home/egor/lua/luac/3.2.lub'...
-- PUC Lua 3.2 Executable detected
lua_Number type: 'String'

== Reading file '/home/egor/lua/luac/4.0.lub'...
-- PUC Lua 4.0 Executable detected
Endianness:           'Little-endian'
int size:             '4'
size_t size:          '8'
lua_Instruction size: '8'
lua_Number size:      '8'
lua_Number type:      'Integer'

== Reading file '/home/egor/lua/luac/5.0.lub'...
-- PUC Lua 5.0 Executable detected
Endianness:           'Little-endian'
int size:             '4'
size_t size:          '8'
lua_Instruction size: '8'
lua_Number size:      '8'
lua_Number type:      'Integer'

== Reading file '/home/egor/lua/luac/5.1.lub'...
-- PUC Lua 5.1 Executable detected
Endianness:           'Little-endian'
int size:             '4'
size_t size:          '8'
lua_Instruction size: '4'
lua_Number size:      '8'
lua_Number type:      'Floating-point'

== Reading file '/home/egor/lua/luac/5.2.lub'...
-- PUC Lua 5.2 Executable detected
Endianness:           'Little-endian'
int size:             '4'
size_t size:          '8'
lua_Instruction size: '4'
lua_Number size:      '8'
lua_Number type:      'Floating-point'

== Reading file '/home/egor/lua/luac/5.3.lub'...
-- PUC Lua 5.3 Executable detected
Endianness:           'Little-endian'
int size:             '4'
size_t size:          '8'
lua_Instruction size: '4'
lua_Integer size:     '8'
lua_Number size:      '8'
lua_Number type:      'Integer'

== Reading file '/home/egor/lua/luac/5.4.lub'...
-- PUC Lua 5.4 Executable detected
Endianness:           'Little-endian'
lua_Instruction size: '4'
lua_Integer size:     '8'
lua_Number size:      '8'
lua_Number type:      'Integer'
```