### PR TITLE
[libromdata] add mirroring info for NES

### DIFF
--- a/src/libromdata/Console/NES.cpp
+++ b/src/libromdata/Console/NES.cpp
@@ -3,7 +3,7 @@
  * NES.cpp: Nintendo Entertainment System/Famicom ROM reader.              *
  *                                                                         *
  * Copyright (c) 2016-2021 by David Korth.                                 *
- * Copyright (c) 2016-2018 by Egor.                                        *
+ * Copyright (c) 2016-2022 by Egor.                                        *
  * SPDX-License-Identifier: GPL-2.0-or-later                               *
  ***************************************************************************/
 
@@ -1058,19 +1058,9 @@ int NES::loadFieldData(void)
 			case NESPrivate::ROM_FORMAT_INES:
 			case NESPrivate::ROM_FORMAT_NES2:
 				// Mirroring
-				// TODO: Detect mappers that have programmable mirroring.
-				// TODO: Also One Screen, e.g. AxROM.
-				if (d->header.ines.mapper_lo & INES_F6_MIRROR_FOUR) {
-					// Four screens using extra VRAM.
-					s_mirroring = C_("NES|Mirroring", "Four Screens");
-				} else {
-					// TODO: There should be a "one screen" option...
-					if (d->header.ines.mapper_lo & INES_F6_MIRROR_VERT) {
-						s_mirroring = C_("NES|Mirroring", "Vertical");
-					} else {
-						s_mirroring = C_("NES|Mirroring", "Horizontal");
-					}
-				}
+				s_mirroring = NESMappers::lookup_ines_mirroring(mapper, submapper == -1 ? 0 : submapper,
+					d->header.ines.mapper_lo & INES_F6_MIRROR_VERT,
+					d->header.ines.mapper_lo & INES_F6_MIRROR_FOUR);
 
 				// Check for NES 2.0 extended console types, including VS hardware.
 				if ((d->romType & (NESPrivate::ROM_SYSTEM_MASK | NESPrivate::ROM_FORMAT_MASK)) ==

--- a/src/libromdata/data/NESMappers.cpp
+++ b/src/libromdata/data/NESMappers.cpp
@@ -992,8 +992,8 @@ const NESMappersPrivate::SubmapperInfo *NESMappersPrivate::lookup_nes2_submapper
 {
 	assert(mapper >= 0);
 	assert(submapper >= 0);
-	assert(submapper < 256);
-	if (mapper < 0 || submapper < 0 || submapper >= 256) {
+	assert(submapper < 16);
+	if (mapper < 0 || submapper < 0 || submapper >= 16) {
 		// Mapper or submapper number is out of range.
 		return nullptr;
 	}

--- a/src/libromdata/data/NESMappers.cpp
+++ b/src/libromdata/data/NESMappers.cpp
@@ -3,7 +3,7 @@
  * NESMappers.cpp: NES mapper data.                                        *
  *                                                                         *
  * Copyright (c) 2016-2021 by David Korth.                                 *
- * Copyright (c) 2016-2018 by Egor.                                        *
+ * Copyright (c) 2016-2022 by Egor.                                        *
  * SPDX-License-Identifier: GPL-2.0-or-later                               *
  ***************************************************************************/
 
@@ -18,6 +18,50 @@ namespace LibRomData {
  * - https://wiki.nesdev.com/w/index.php/NES_2.0_submappers
  */
 
+// Mirroring behaviors for different mappers
+enum NESMirroringType {
+	MIRRORING_UNKNOWN = 0,		// When submapper has this value, it inherits mapper's value
+	// NOTE: for all of these we assume that if 4-Screen bit is set it means that the mapper's
+	// logic gets ignored, and there's simply 4K of SRAM at $2000. For more complicated mappers
+	// (MMC5) this would actually be a downgrade, and maybe even impossible, but iNES format
+	// applies the same logic to all mappers (except 30 and 218, see below)
+	// Reference: http://wiki.nesdev.com/w/index.php/NES_2.0#Hard-Wired_Mirroring
+	// NOTE: H/V/A/B refers to CIRAM A10 being connected to PPU A11/A10/Vss/Vdd respectively
+	// NOTE: boards that only ever existed in H or V configuration still use the H/V bit.
+	MIRRORING_HEADER,		// fixed H/V (the default)
+	MIRRORING_MAPPER,		// Mapper-controlled (unspecified)
+	MIRRORING_MAPPER_HVAB,		// - switchable H/V/A/B (e.g. MMC1)
+	MIRRORING_MAPPER_HV,		// - switchable H/V     (e.g. MMC3)
+	MIRRORING_MAPPER_AB,		// - switchable A/B     (e.g. AxROM)
+	MIRRORING_MAPPER_MMC5,		// - arbitrary configuration with 3 NTs and fill mode
+	MIRRORING_MAPPER_NAMCO163,	// - arbitrary configuration with 2 RAM and 224 ROM NTs
+	MIRRORING_MAPPER_VRC6,		// - it's complicated (Konami games only use H/V/A/B)
+	MIRRORING_MAPPER_JY,		// - J.Y. Company ASIC mapper (also complicated)
+	MIRRORING_MAPPER_SUNSOFT4,	// - switchable H/V/A/B with 2 RAM and 128 ROM NTs
+	MIRRORING_MAPPER_NAMCOT3425,	// - H but you can select how PPU A11 maps to CIRAM A10
+					//   (effectively it's selectable H/A/B/swapped-H)
+	MIRRORING_MAPPER_GTROM,		// - paged 4 screen RAM
+	MIRRORING_MAPPER_TxSROM,	// - arbitrary configuration with 2 NTs
+	MIRRORING_MAPPER_SACHEN8259,	// - switchable H/V/A/L-shaped (A10 or A11)
+	MIRRORING_MAPPER_SACHEN74LS374N,// - switchable H/V/A/L-shaped (A10 and A11)
+	MIRRORING_MAPPER_DIS23C01,	// - switchable H/V. A on reset.
+	MIRRORING_MAPPER_233,		// - switchable H/V/B/L-shaped (A10 and A11)
+	MIRRORING_MAPPER_235,		// - switchable H/V/A
+	MIRRORING_1SCREEN_A,		// fixed A
+	MIRRORING_1SCREEN_B,		// fixed B
+					// (the distinction is only relevant for Magic Floor)
+	MIRRORING_4SCREEN,		// 4 screen regardless of header (e.g. Vs. System)
+	// The following mappers interpret the header bits differently
+	MIRRORING_UNROM512,		// fixed H/V/4 or switchable A/B (mapper 30)
+	MIRRORING_BANDAI_FAMILYTRAINER,	// fixed H/V or switchable A/B (mapper 70) (see note below)
+	MIRRORING_MAGICFLOOR,		// fixed H/V/A/B (mapper 218)
+
+	// NOTE: fwNES describes mappers 70 and 78 as using 4 Screen bit to specify switchable A/B
+	// - 70 normally has fixed H/V. For switchable A/B, 152 should be used instead.
+	// - 78 has either switchable H/V or switchable A/B. Emulators default to one of those,
+	// and use checksumming to detect the other. Submappers should be used instead.
+};
+
 class NESMappersPrivate
 {
 	private:
@@ -27,10 +71,12 @@ class NESMappersPrivate
 		RP_DISABLE_COPY(NESMappersPrivate)
 
 	public:
+
 		// iNES mapper list.
 		struct MapperEntry {
 			const char *name;		// Name of the board. (If unknown, nullptr.)
 			const char *manufacturer;	// Manufacturer. (If unknown, nullptr.)
+			NESMirroringType mirroring;	// Mirroring behavior.
 		};
 		static const MapperEntry mappers_plane0[];
 		static const MapperEntry mappers_plane1[];
@@ -49,10 +95,11 @@ class NESMappersPrivate
 		 * It is assumed that the replacement mapper always uses submapper 0.
 		 */
 		struct SubmapperInfo {
-			uint8_t submapper;	// Submapper number.
+			uint8_t submapper;		// Submapper number.
 			uint8_t reserved;
 			uint16_t deprecated;
-			const char *desc;	// Description.
+			const char *desc;		// Description.
+			NESMirroringType mirroring;	// Mirroring behavior.
 		};
 
 		// Submappers.
@@ -108,717 +155,724 @@ class NESMappersPrivate
 		 * @return
 		 */
 		static int RP_C_API SubmapperEntry_compar(const void *a, const void *b);
+
+		/**
+		 * Look up an iNES mapper number.
+		 * @param mapper Mapper number.
+		 * @return Mapper info, or nullptr if not found.
+		 */
+		static const MapperEntry *lookup_ines_info(int mapper);
+
+		/**
+		 * Look up an NES 2.0 submapper number.
+		 * @param mapper Mapper number.
+		 * @param submapper Submapper number.
+		 * @return Submapper info, or nullptr if not found.
+		 */
+		static const SubmapperInfo *lookup_nes2_submapper_info(int mapper, int submapper);
 };
 
 /**
  * Mappers: NES 2.0 Plane 0 [000-255] (iNES 1.0)
- * TODO: Add more fields:
- * - Programmable mirroring
- * - Extra VRAM for 4 screens
  */
 const NESMappersPrivate::MapperEntry NESMappersPrivate::mappers_plane0[] = {
 	/** NES 2.0 Plane 0 [0-255] (iNES 1.0) **/
 
 	// Mappers 000-009
-	{"NROM",			"Nintendo"},
-	{"SxROM (MMC1)",		"Nintendo"},
-	{"UxROM",			"Nintendo"},
-	{"CNROM",			"Nintendo"},
-	{"TxROM (MMC3), HKROM (MMC6)",	"Nintendo"},
-	{"ExROM (MMC5)",		"Nintendo"},
-	{"Game Doctor Mode 1",		"Bung/FFE"},
-	{"AxROM",			"Nintendo"},
-	{"Game Doctor Mode 4 (GxROM)",	"Bung/FFE"},
-	{"PxROM, PEEOROM (MMC2)",	"Nintendo"},
+	{"NROM",			"Nintendo",		MIRRORING_HEADER},
+	{"SxROM (MMC1)",		"Nintendo",		MIRRORING_MAPPER_HVAB},
+	{"UxROM",			"Nintendo",		MIRRORING_HEADER},
+	{"CNROM",			"Nintendo",		MIRRORING_HEADER},
+	{"TxROM (MMC3), HKROM (MMC6)",	"Nintendo",		MIRRORING_MAPPER_HV},
+	{"ExROM (MMC5)",		"Nintendo",		MIRRORING_MAPPER_MMC5},
+	{"Game Doctor Mode 1",		"Bung/FFE",		MIRRORING_MAPPER_HVAB},
+	{"AxROM",			"Nintendo",		MIRRORING_MAPPER_AB},
+	{"Game Doctor Mode 4 (GxROM)",	"Bung/FFE",		MIRRORING_MAPPER_HVAB},
+	{"PxROM, PEEOROM (MMC2)",	"Nintendo",		MIRRORING_MAPPER_HV},
 
 	// Mappers 010-019
-	{"FxROM (MMC4)",		"Nintendo"},
-	{"Color Dreams",		"Color Dreams"},
-	{"MMC3 variant",		"FFE"},
-	{"NES-CPROM",			"Nintendo"},
-	{"SL-1632 (MMC3/VRC2 clone)",	"Nintendo"},
-	{"K-1029 (multicart)",		nullptr},
-	{"FCG-x",			"Bandai"},
-	{"FFE #17",			"FFE"},
-	{"SS 88006",			"Jaleco"},
-	{"Namco 129/163",		"Namco"},	// TODO: Namcot-106?
+	{"FxROM (MMC4)",		"Nintendo",		MIRRORING_MAPPER_HV},
+	{"Color Dreams",		"Color Dreams",		MIRRORING_HEADER},
+	{"MMC3 variant",		"FFE",			MIRRORING_MAPPER_HV},
+	{"NES-CPROM",			"Nintendo",		MIRRORING_HEADER},
+	{"SL-1632 (MMC3/VRC2 clone)",	"Nintendo",		MIRRORING_MAPPER_HVAB},
+	{"K-1029 (multicart)",		nullptr,		MIRRORING_MAPPER_HV},
+	{"FCG-x",			"Bandai",		MIRRORING_MAPPER_HVAB},
+	{"FFE #17",			"FFE",			MIRRORING_MAPPER_HVAB},
+	{"SS 88006",			"Jaleco",		MIRRORING_MAPPER_HVAB},
+	{"Namco 129/163",		"Namco",		MIRRORING_MAPPER_NAMCO163},	// TODO: Namcot-106?
 
 	// Mappers 020-029
-	{"Famicom Disk System",		"Nintendo"}, // this isn't actually used, as FDS roms are stored in their own format.
-	{"VRC4a, VRC4c",		"Konami"},
-	{"VRC2a",			"Konami"},
-	{"VRC4e, VRC4f, VRC2b",		"Konami"},
-	{"VRC6a",			"Konami"},
-	{"VRC4b, VRC4d, VRC2c",		"Konami"},
-	{"VRC6b",			"Konami"},
-	{"VRC4 variant",		nullptr}, //investigate
-	{"Action 53",			"Homebrew"},
-	{"RET-CUFROM",			"Sealie Computing"},	// Homebrew
+	{"Famicom Disk System",		"Nintendo",		MIRRORING_MAPPER_HV}, // this isn't actually used, as FDS roms are stored in their own format.
+	{"VRC4a, VRC4c",		"Konami",		MIRRORING_MAPPER_HVAB},
+	{"VRC2a",			"Konami",		MIRRORING_MAPPER_HVAB},
+	{"VRC4e, VRC4f, VRC2b",		"Konami",		MIRRORING_MAPPER_HVAB},
+	{"VRC6a",			"Konami",		MIRRORING_MAPPER_VRC6},
+	{"VRC4b, VRC4d, VRC2c",		"Konami",		MIRRORING_MAPPER_HVAB},
+	{"VRC6b",			"Konami",		MIRRORING_MAPPER_VRC6},
+	{"VRC4 variant",		nullptr,		MIRRORING_MAPPER_HVAB}, //investigate
+	{"Action 53",			"Homebrew",		MIRRORING_MAPPER_HVAB},
+	{"RET-CUFROM",			"Sealie Computing",	MIRRORING_HEADER},	// Homebrew
 
 	// Mappers 030-039
-	{"UNROM 512",			"RetroUSB"},	// Homebrew
-	{"NSF Music Compilation",	"Homebrew"},
-	{"Irem G-101",			"Irem"},
-	{"Taito TC0190",		"Taito"},
-	{"BNROM, NINA-001",		nullptr},
-	{"J.Y. Company ASIC (8 KiB WRAM)", "J.Y. Company"},
-	{"TXC PCB 01-22000-400",	"TXC"},
-	{"MMC3 multicart",		"Nintendo"},
-	{"GNROM variant",		"Bit Corp."},
-	{"BNROM variant",		nullptr},
+	{"UNROM 512",			"RetroUSB",		MIRRORING_UNROM512},	// Homebrew
+	{"NSF Music Compilation",	"Homebrew",		MIRRORING_HEADER},
+	{"Irem G-101",			"Irem",			MIRRORING_MAPPER_HV /* see submapper */},
+	{"Taito TC0190",		"Taito",		MIRRORING_MAPPER_HV},
+	{"BNROM, NINA-001",		nullptr,		MIRRORING_HEADER},
+	{"J.Y. Company ASIC (8 KiB WRAM)", "J.Y. Company",	MIRRORING_MAPPER_JY},
+	{"TXC PCB 01-22000-400",	"TXC",			MIRRORING_MAPPER_HV},
+	{"MMC3 multicart",		"Nintendo",		MIRRORING_MAPPER_HV},
+	{"GNROM variant",		"Bit Corp.",		MIRRORING_HEADER},
+	{"BNROM variant",		nullptr,		MIRRORING_HEADER},
 
 	// Mappers 040-049
-	{"NTDEC 2722 (FDS conversion)",	"NTDEC"},
-	{"Caltron 6-in-1",		"Caltron"},
-	{"FDS conversion",		nullptr},
-	{"TONY-I, YS-612 (FDS conversion)", nullptr},
-	{"MMC3 multicart",		nullptr},
-	{"MMC3 multicart (GA23C)",	nullptr},
-	{"Rumble Station 15-in-1",	"Color Dreams"},	// NES-on-a-Chip
-	{"MMC3 multicart",		"Nintendo"},
-	{"Taito TC0690",		"Taito"},	// TODO: Taito-TC190V?
-	{"MMC3 multicart",		nullptr},
+	{"NTDEC 2722 (FDS conversion)",	"NTDEC",		MIRRORING_HEADER},
+	{"Caltron 6-in-1",		"Caltron",		MIRRORING_MAPPER_HV},
+	{"FDS conversion",		nullptr,		MIRRORING_MAPPER_HV},
+	{"TONY-I, YS-612 (FDS conversion)", nullptr,		MIRRORING_HEADER},
+	{"MMC3 multicart",		nullptr,		MIRRORING_MAPPER_HV},
+	{"MMC3 multicart (GA23C)",	nullptr,		MIRRORING_MAPPER_HV},
+	{"Rumble Station 15-in-1",	"Color Dreams",		MIRRORING_HEADER},	// NES-on-a-Chip
+	{"MMC3 multicart",		"Nintendo",		MIRRORING_MAPPER_HV},
+	{"Taito TC0690",		"Taito",		MIRRORING_MAPPER_HV},	// TODO: Taito-TC190V?
+	{"MMC3 multicart",		nullptr,		MIRRORING_MAPPER_HV},
 
 	// Mappers 050-059
-	{"PCB 761214 (FDS conversion)",	"N-32"},
-	{nullptr,			nullptr},
-	{"MMC3 multicart",		nullptr},
-	{nullptr,			nullptr},
-	{"Novel Diamond 9999999-in-1",	nullptr},	// conflicting information
-	{"BTL-MARIO1-MALEE2",		nullptr},	// From UNIF
-	{"KS202 (unlicensed SMB3 reproduction)", nullptr},	// Some SMB3 unlicensed reproduction
-	{"Multicart",			nullptr},
-	{"(C)NROM-based multicart",	nullptr},
-	{"BMC-T3H53/BMC-D1038 multicart", nullptr},	// From UNIF
+	{"PCB 761214 (FDS conversion)",	"N-32",			MIRRORING_HEADER},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"MMC3 multicart",		nullptr,		MIRRORING_MAPPER_HV},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"Novel Diamond 9999999-in-1",	nullptr,		MIRRORING_UNKNOWN},	// conflicting information
+	{"BTL-MARIO1-MALEE2",		nullptr,		MIRRORING_HEADER},	// From UNIF
+	{"KS202 (unlicensed SMB3 reproduction)", nullptr,	MIRRORING_MAPPER_HV},	// Some SMB3 unlicensed reproduction
+	{"Multicart",			nullptr,		MIRRORING_MAPPER_HV},
+	{"(C)NROM-based multicart",	nullptr,		MIRRORING_MAPPER_HV},
+	{"BMC-T3H53/BMC-D1038 multicart", nullptr,		MIRRORING_MAPPER_HV},	// From UNIF
 
 	// Mappers 060-069
-	{"Reset-based NROM-128 4-in-1 multicart", nullptr},
-	{"20-in-1 multicart",		nullptr},
-	{"Super 700-in-1 multicart",	nullptr},
-	{"Powerful 250-in-1 multicart",	"NTDEC"},
-	{"Tengen RAMBO-1",		"Tengen"},
-	{"Irem H3001",			"Irem"},
-	{"GxROM, MHROM",		"Nintendo"},
-	{"Sunsoft-3",			"Sunsoft"},
-	{"Sunsoft-4",			"Sunsoft"},
-	{"Sunsoft FME-7",		"Sunsoft"},
+	{"Reset-based NROM-128 4-in-1 multicart", nullptr,	MIRRORING_HEADER},
+	{"20-in-1 multicart",		nullptr,		MIRRORING_MAPPER_HV},
+	{"Super 700-in-1 multicart",	nullptr,		MIRRORING_MAPPER_HV},
+	{"Powerful 250-in-1 multicart",	"NTDEC",		MIRRORING_MAPPER_HV},
+	{"Tengen RAMBO-1",		"Tengen",		MIRRORING_MAPPER_HV},
+	{"Irem H3001",			"Irem",			MIRRORING_MAPPER_HV},
+	{"GxROM, MHROM",		"Nintendo",		MIRRORING_HEADER},
+	{"Sunsoft-3",			"Sunsoft",		MIRRORING_MAPPER_HVAB},
+	{"Sunsoft-4",			"Sunsoft",		MIRRORING_MAPPER_SUNSOFT4},
+	{"Sunsoft FME-7",		"Sunsoft",		MIRRORING_MAPPER_HVAB},
 
 	// Mappers 070-079
-	{"Family Trainer",		"Bandai"},
-	{"Codemasters (UNROM clone)",	"Codemasters"},
-	{"Jaleco JF-17",		"Jaleco"},	// TODO: Jaleco-2?
-	{"VRC3",			"Konami"},
-	{"43-393/860908C (MMC3 clone)",	"Waixing"},
-	{"VRC1",			"Konami"},
-	{"NAMCOT-3446 (Namcot 108 variant)",	"Namco"},	// TODO: Namco-109?
-	{"Napoleon Senki",		"Lenar"},		// TODO: Irem-1?
-	{"Holy Diver; Uchuusen - Cosmo Carrier", nullptr},	// TODO: Irem-74HC161?
-	{"NINA-03, NINA-06",		"American Video Entertainment"},
+	{"Family Trainer",		"Bandai",		MIRRORING_HEADER /* see wiki for a caveat */},
+	{"Codemasters (UNROM clone)",	"Codemasters",		MIRRORING_HEADER /* see submapper */},
+	{"Jaleco JF-17",		"Jaleco",		MIRRORING_HEADER},	// TODO: Jaleco-2?
+	{"VRC3",			"Konami",		MIRRORING_HEADER},
+	{"43-393/860908C (MMC3 clone)",	"Waixing",		MIRRORING_MAPPER_HV},
+	{"VRC1",			"Konami",		MIRRORING_MAPPER_HV},
+	{"NAMCOT-3446 (Namcot 108 variant)",	"Namco",	MIRRORING_HEADER},	// TODO: Namco-109?
+	{"Napoleon Senki",		"Lenar",		MIRRORING_4SCREEN},	// TODO: Irem-1? 
+	{"Holy Diver; Uchuusen - Cosmo Carrier", nullptr,	MIRRORING_MAPPER /* see submapper */},	// TODO: Irem-74HC161?
+	{"NINA-03, NINA-06",		"American Video Entertainment", MIRRORING_HEADER},
 
 	// Mappers 080-089
-	{"Taito X1-005",		"Taito"},
-	{"Super Gun",			"NTDEC"},
-	{"Taito X1-017 (incorrect PRG ROM bank ordering)", "Taito"},
-	{"Cony/Yoko",			"Cony/Yoko"},
-	{"PC-SMB2J",			nullptr},
-	{"VRC7",			"Konami"},
-	{"Jaleco JF-13",		"Jaleco"},	// TODO: Jaleco-4?
-	{"CNROM variant",		nullptr},	// TODO: Jaleco-1?
-	{"Namcot 118 variant",		nullptr},	// TODO: Namco-118?
-	{"Sunsoft-2 (Sunsoft-3 board)",	"Sunsoft"},
+	{"Taito X1-005",		"Taito",		MIRRORING_MAPPER_HV},
+	{"Super Gun",			"NTDEC",		MIRRORING_HEADER},
+	{"Taito X1-017 (incorrect PRG ROM bank ordering)", "Taito", MIRRORING_MAPPER_HV},
+	{"Cony/Yoko",			"Cony/Yoko",		MIRRORING_MAPPER_HVAB},
+	{"PC-SMB2J",			nullptr,		MIRRORING_UNKNOWN},
+	{"VRC7",			"Konami",		MIRRORING_MAPPER_HVAB},
+	{"Jaleco JF-13",		"Jaleco",		MIRRORING_HEADER},	// TODO: Jaleco-4?
+	{"CNROM variant",		nullptr,		MIRRORING_HEADER},	// TODO: Jaleco-1?
+	{"Namcot 118 variant",		nullptr,		MIRRORING_HEADER},	// TODO: Namco-118?
+	{"Sunsoft-2 (Sunsoft-3 board)",	"Sunsoft",		MIRRORING_MAPPER_AB},
 
 	// Mappers 090-099
-	{"J.Y. Company (simple nametable control)", "J.Y. Company"},
-	{"J.Y. Company (Super Fighter III)", "J.Y. Company"},
-	{"Moero!! Pro",			"Jaleco"},	// TODO: Jaleco-3?
-	{"Sunsoft-2 (Sunsoft-3R board)", "Sunsoft"},	// TODO: 74161A?
-	{"HVC-UN1ROM",			"Nintendo"},	// TODO: 74161B?
-	{"NAMCOT-3425",			"Namco"},	// TODO: Namcot?
-	{"Oeka Kids",			"Bandai"},
-	{"Irem TAM-S1",			"Irem"},	// TODO: Irem-2?
-	{nullptr,			nullptr},
-	{"CNROM (Vs. System)",		"Nintendo"},
+	{"J.Y. Company (simple nametable control)", "J.Y. Company", MIRRORING_MAPPER_HVAB},
+	{"J.Y. Company (Super Fighter III)", "J.Y. Company",	MIRRORING_MAPPER_HV /* see submapper */},
+	{"Moero!! Pro",			"Jaleco",		MIRRORING_HEADER},	// TODO: Jaleco-3?
+	{"Sunsoft-2 (Sunsoft-3R board)", "Sunsoft",		MIRRORING_HEADER},	// TODO: 74161A?
+	{"HVC-UN1ROM",			"Nintendo",		MIRRORING_HEADER},	// TODO: 74161B?
+	{"NAMCOT-3425",			"Namco",		MIRRORING_MAPPER_NAMCOT3425},	// TODO: Namcot?
+	{"Oeka Kids",			"Bandai",		MIRRORING_HEADER},
+	{"Irem TAM-S1",			"Irem",			MIRRORING_MAPPER_HV},	// TODO: Irem-2?
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"CNROM (Vs. System)",		"Nintendo",		MIRRORING_4SCREEN},
 
 	// Mappers 100-109
-	{"MMC3 variant (hacked ROMs)",	nullptr},	// Also used for UNIF
-	{"Jaleco JF-10 (misdump)",	"Jaleceo"},
-	{nullptr,			nullptr},
-	{"Doki Doki Panic (FDS conversion)", nullptr},
-	{"PEGASUS 5 IN 1",		nullptr},
-	{"NES-EVENT (MMC1 variant) (Nintendo World Championships 1990)", "Nintendo"},
-	{"Super Mario Bros. 3 (bootleg)", nullptr},
-	{"Magic Dragon",		"Magicseries"},
-	{nullptr,			nullptr},
-	{nullptr,			nullptr},
+	{"MMC3 variant (hacked ROMs)",	nullptr,		MIRRORING_MAPPER_HV},	// Also used for UNIF
+	{"Jaleco JF-10 (misdump)",	"Jaleceo",		MIRRORING_HEADER},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"Doki Doki Panic (FDS conversion)", nullptr,		MIRRORING_MAPPER_HV},
+	{"PEGASUS 5 IN 1",		nullptr,		MIRRORING_HEADER},
+	{"NES-EVENT (MMC1 variant) (Nintendo World Championships 1990)", "Nintendo", MIRRORING_MAPPER_HVAB},
+	{"Super Mario Bros. 3 (bootleg)", nullptr,		MIRRORING_MAPPER_HV},
+	{"Magic Dragon",		"Magicseries",		MIRRORING_HEADER},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
 
 	// Mappers 110-119
-	{nullptr,			nullptr},
-	{"Cheapocabra GTROM 512k flash board", "Membler Industries"},	// Homebrew
-	{"Namcot 118 variant",		nullptr},
-	{"NINA-03/06 multicart",	nullptr},
-	{"MMC3 clone (scrambled registers)", nullptr},
-	{"Kǎshèng SFC-02B/-03/-004 (MMC3 clone)", "Kǎshèng"},
-	{"SOMARI-P (Huang-1/Huang-2)",	"Gouder"},
-	{nullptr,			nullptr},
-	{"TxSROM",			"Nintendo"},	// TODO: MMC-3+TLS?
-	{"TQROM",			"Nintendo"},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"Cheapocabra GTROM 512k flash board", "Membler Industries", MIRRORING_MAPPER_GTROM},	// Homebrew
+	{"Namcot 118 variant",		nullptr,		MIRRORING_MAPPER_HV},
+	{"NINA-03/06 multicart",	nullptr,		MIRRORING_MAPPER_HV},
+	{"MMC3 clone (scrambled registers)", nullptr,		MIRRORING_MAPPER_HV},
+	{"Kǎshèng SFC-02B/-03/-004 (MMC3 clone)", "Kǎshèng",	MIRRORING_MAPPER_HV},
+	{"SOMARI-P (Huang-1/Huang-2)",	"Gouder",		MIRRORING_MAPPER_HVAB},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"TxSROM",			"Nintendo",		MIRRORING_MAPPER_TxSROM},	// TODO: MMC-3+TLS?
+	{"TQROM",			"Nintendo",		MIRRORING_MAPPER_HV},
 
 	// Mappers 120-129
-	{nullptr,			nullptr},
-	{"Kǎshèng A9711 and A9713 (MMC3 clone)", "Kǎshèng"},
-	{nullptr,			nullptr},
-	{"Kǎshèng H2288 (MMC3 clone)",	"Kǎshèng"},
-	{nullptr,			nullptr},
-	{"Monty no Doki Doki Daisassō (FDS conversion)", "Whirlwind Manu"},
-	{nullptr,			nullptr},
-	{nullptr,			nullptr},
-	{nullptr,			nullptr},
-	{nullptr,			nullptr},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"Kǎshèng A9711 and A9713 (MMC3 clone)", "Kǎshèng",	MIRRORING_MAPPER_HV},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"Kǎshèng H2288 (MMC3 clone)",	"Kǎshèng",		MIRRORING_MAPPER_HV},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"Monty no Doki Doki Daisassō (FDS conversion)", "Whirlwind Manu", MIRRORING_HEADER},
+	{nullptr,			nullptr,		MIRRORING_MAPPER_HV},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
 
 	// Mappers 130-139
-	{nullptr,			nullptr},
-	{nullptr,			nullptr},
-	{"TXC 05-00002-010 ASIC",	"TXC"},
-	{"Jovial Race",			"Sachen"},
-	{"T4A54A, WX-KB4K, BS-5652 (MMC3 clone)", nullptr},
-	{nullptr,			nullptr},
-	{"Sachen 3011",			"Sachen"},
-	{"Sachen 8259D",		"Sachen"},
-	{"Sachen 8259B",		"Sachen"},
-	{"Sachen 8259C",		"Sachen"},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"TXC 05-00002-010 ASIC",	"TXC",			MIRRORING_HEADER},
+	{"Jovial Race",			"Sachen",		MIRRORING_HEADER},
+	{"T4A54A, WX-KB4K, BS-5652 (MMC3 clone)", nullptr,	MIRRORING_MAPPER_HV},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"Sachen 3011",			"Sachen",		MIRRORING_HEADER},
+	{"Sachen 8259D",		"Sachen",		MIRRORING_MAPPER_SACHEN8259},
+	{"Sachen 8259B",		"Sachen",		MIRRORING_MAPPER_SACHEN8259},
+	{"Sachen 8259C",		"Sachen",		MIRRORING_MAPPER_SACHEN8259},
 
 	// Mappers 140-149
-	{"Jaleco JF-11, JF-14 (GNROM variant)", "Jaleco"},
-	{"Sachen 8259A",		"Sachen"},
-	{"Kaiser KS202 (FDS conversions)", "Kaiser"},
-	{"Copy-protected NROM",		nullptr},
-	{"Death Race (Color Dreams variant)", "American Game Cartridges"},
-	{"Sidewinder (CNROM clone)",	"Sachen"},
-	{"Galactic Crusader (NINA-06 clone)", nullptr},
-	{"Sachen 3018",			"Sachen"},
-	{"Sachen SA-008-A, Tengen 800008",	"Sachen / Tengen"},
-	{"SA-0036 (CNROM clone)",	"Sachen"},
+	{"Jaleco JF-11, JF-14 (GNROM variant)", "Jaleco",	MIRRORING_HEADER},
+	{"Sachen 8259A",		"Sachen",		MIRRORING_MAPPER_SACHEN8259},
+	{"Kaiser KS202 (FDS conversions)", "Kaiser",		MIRRORING_HEADER},
+	{"Copy-protected NROM",		nullptr,		MIRRORING_HEADER},
+	{"Death Race (Color Dreams variant)", "American Game Cartridges", MIRRORING_HEADER},
+	{"Sidewinder (CNROM clone)",	"Sachen",		MIRRORING_HEADER},
+	{"Galactic Crusader (NINA-06 clone)", nullptr,		MIRRORING_HEADER},
+	{"Sachen 3018",			"Sachen",		MIRRORING_HEADER},
+	{"Sachen SA-008-A, Tengen 800008",	"Sachen / Tengen", MIRRORING_HEADER},
+	{"SA-0036 (CNROM clone)",	"Sachen",		MIRRORING_HEADER},
 
 	// Mappers 150-159
-	{"Sachen SA-015, SA-630",	"Sachen"},
-	{"VRC1 (Vs. System)",		"Konami"},
-	{"Kaiser KS202 (FDS conversion)", "Kaiser"},
-	{"Bandai FCG: LZ93D50 with SRAM", "Bandai"},
-	{"NAMCOT-3453",			"Namco"},
-	{"MMC1A",			"Nintendo"},
-	{"DIS23C01",			"Daou Infosys"},
-	{"Datach Joint ROM System",	"Bandai"},
-	{"Tengen 800037",		"Tengen"},
-	{"Bandai LZ93D50 with 24C01",	"Bandai"},
+	{"Sachen SA-015, SA-630",	"Sachen",		MIRRORING_MAPPER_SACHEN74LS374N},
+	{"VRC1 (Vs. System)",		"Konami",		MIRRORING_4SCREEN},
+	{"Kaiser KS202 (FDS conversion)", "Kaiser",		MIRRORING_MAPPER_AB},
+	{"Bandai FCG: LZ93D50 with SRAM", "Bandai",		MIRRORING_MAPPER_HVAB},
+	{"NAMCOT-3453",			"Namco",		MIRRORING_MAPPER_AB},
+	{"MMC1A",			"Nintendo",		MIRRORING_MAPPER_HVAB},
+	{"DIS23C01",			"Daou Infosys",		MIRRORING_MAPPER_DIS23C01},
+	{"Datach Joint ROM System",	"Bandai",		MIRRORING_MAPPER_HVAB},
+	{"Tengen 800037",		"Tengen",		MIRRORING_MAPPER_TxSROM},
+	{"Bandai LZ93D50 with 24C01",	"Bandai",		MIRRORING_MAPPER_HVAB},
 
 	// Mappers 160-169
-	{nullptr,			nullptr},
-	{nullptr,			nullptr},
-	{nullptr,			nullptr},
-	{"Nanjing",			"Nanjing"},
-	{"Waixing (unlicensed)",	"Waixing"},
-	{"Fire Emblem (unlicensed) (MMC2+MMC3 hybrid)", nullptr},
-	{"Subor (variant 1)",		"Subor"},
-	{"Subor (variant 2)",		"Subor"},
-	{"Racermate Challenge 2",	"Racermate, Inc."},
-	{"Yuxing",			"Yuxing"},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"Nanjing",			"Nanjing",		MIRRORING_HEADER},
+	{"Waixing (unlicensed)",	"Waixing",		MIRRORING_HEADER},
+	{"Fire Emblem (unlicensed) (MMC2+MMC3 hybrid)", nullptr, MIRRORING_MAPPER_HV},
+	{"Subor (variant 1)",		"Subor",		MIRRORING_HEADER},
+	{"Subor (variant 2)",		"Subor",		MIRRORING_HEADER},
+	{"Racermate Challenge 2",	"Racermate, Inc.",	MIRRORING_HEADER},
+	{"Yuxing",			"Yuxing",		MIRRORING_UNKNOWN},
 
 	// Mappers 170-179
-	{nullptr,			nullptr},
-	{"Kaiser KS-7058",		"Kaiser"},
-	{"Super Mega P-4040",		nullptr},
-	{"Idea-Tek ET-xx",		"Idea-Tek"},
-	{"Multicart",			nullptr},
-	{nullptr,			nullptr},
-	{"Waixing multicart (MMC3 clone)", "Waixing"},
-	{"BNROM variant",		"Hénggé Diànzǐ"},
-	{"Waixing / Nanjing / Jncota / Henge Dianzi / GameStar", "Waixing / Nanjing / Jncota / Henge Dianzi / GameStar"},
-	{nullptr,			nullptr},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"Kaiser KS-7058",		"Kaiser",		MIRRORING_HEADER},
+	{"Super Mega P-4040",		nullptr,		MIRRORING_MAPPER_HV},
+	{"Idea-Tek ET-xx",		"Idea-Tek",		MIRRORING_HEADER},
+	{"Multicart",			nullptr,		MIRRORING_MAPPER_HV},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"Waixing multicart (MMC3 clone)", "Waixing",		MIRRORING_MAPPER_HVAB},
+	{"BNROM variant",		"Hénggé Diànzǐ",	MIRRORING_MAPPER_HV},
+	{"Waixing / Nanjing / Jncota / Henge Dianzi / GameStar", "Waixing / Nanjing / Jncota / Henge Dianzi / GameStar", MIRRORING_MAPPER_HV},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
 
 	// Mappers 180-189
-	{"Crazy Climber (UNROM clone)",	"Nichibutsu"},
-	{"Seicross v2 (FCEUX hack)",	"Nichibutsu"},
-	{"MMC3 clone (scrambled registers) (same as 114)", nullptr},
-	{"Suikan Pipe (VRC4e clone)",	nullptr},
-	{"Sunsoft-1",			"Sunsoft"},
-	{"CNROM with weak copy protection", nullptr},	// Submapper field indicates required value for CHR banking. (TODO: VROM-disable?)
-	{"Study Box",			"Fukutake Shoten"},
-	{"Kǎshèng A98402 (MMC3 clone)",	"Kǎshèng"},
-	{"Bandai Karaoke Studio",	"Bandai"},
-	{"Thunder Warrior (MMC3 clone)", nullptr},
+	{"Crazy Climber (UNROM clone)",	"Nichibutsu",		MIRRORING_HEADER},
+	{"Seicross v2 (FCEUX hack)",	"Nichibutsu",		MIRRORING_HEADER},
+	{"MMC3 clone (scrambled registers) (same as 114)", nullptr, MIRRORING_MAPPER_HV},
+	{"Suikan Pipe (VRC4e clone)",	nullptr,		MIRRORING_MAPPER_HVAB},
+	{"Sunsoft-1",			"Sunsoft",		MIRRORING_HEADER},
+	{"CNROM with weak copy protection", nullptr,		MIRRORING_HEADER},	// Submapper field indicates required value for CHR banking. (TODO: VROM-disable?)
+	{"Study Box",			"Fukutake Shoten",	MIRRORING_HEADER},
+	{"Kǎshèng A98402 (MMC3 clone)",	"Kǎshèng",		MIRRORING_MAPPER_HV},
+	{"Bandai Karaoke Studio",	"Bandai",		MIRRORING_MAPPER_HV},
+	{"Thunder Warrior (MMC3 clone)", nullptr,		MIRRORING_MAPPER_HV},
 
 	// Mappers 190-199
-	{"Magic Kid GooGoo",		nullptr},
-	{"MMC3 clone",			nullptr},
-	{"MMC3 clone",			nullptr},
-	{"NTDEC TC-112",		"NTDEC"},
-	{"MMC3 clone",			nullptr},
-	{"Waixing FS303 (MMC3 clone)",	"Waixing"},
-	{"Mario bootleg (MMC3 clone)",	nullptr},
-	{"Kǎshèng (MMC3 clone)",	"Kǎshèng"},
-	{"Tūnshí Tiāndì - Sānguó Wàizhuàn", nullptr},
-	{"Waixing (clone of either Mapper 004 or 176)", "Waixing"},
+	{"Magic Kid GooGoo",		nullptr,		MIRRORING_HEADER},
+	{"MMC3 clone",			nullptr,		MIRRORING_MAPPER_HV},
+	{"MMC3 clone",			nullptr,		MIRRORING_MAPPER_HV},
+	{"NTDEC TC-112",		"NTDEC",		MIRRORING_MAPPER_HV},
+	{"MMC3 clone",			nullptr,		MIRRORING_MAPPER_HV},
+	{"Waixing FS303 (MMC3 clone)",	"Waixing",		MIRRORING_MAPPER_HV},
+	{"Mario bootleg (MMC3 clone)",	nullptr,		MIRRORING_MAPPER_HV},
+	{"Kǎshèng (MMC3 clone)",	"Kǎshèng",		MIRRORING_MAPPER_HV /* not sure */},
+	{"Tūnshí Tiāndì - Sānguó Wàizhuàn", nullptr,		MIRRORING_MAPPER_HV},
+	{"Waixing (clone of either Mapper 004 or 176)", "Waixing", MIRRORING_MAPPER_HVAB},
 
 	// Mappers 200-209
-	{"Multicart",			nullptr},
-	{"NROM-256 multicart",		nullptr},
-	{"150-in-1 multicart",		nullptr},
-	{"35-in-1 multicart",		nullptr},
-	{nullptr,			nullptr},
-	{"MMC3 multicart",		nullptr},
-	{"DxROM (Tengen MIMIC-1, Namcot 118)", "Nintendo"},
-	{"Fudou Myouou Den",		"Taito"},
-	{"Street Fighter IV (unlicensed) (MMC3 clone)", nullptr},
-	{"J.Y. Company (MMC2/MMC4 clone)", "J.Y. Company"},
+	{"Multicart",			nullptr,		MIRRORING_MAPPER_HV},
+	{"NROM-256 multicart",		nullptr,		MIRRORING_HEADER},
+	{"150-in-1 multicart",		nullptr,		MIRRORING_MAPPER_HV},
+	{"35-in-1 multicart",		nullptr,		MIRRORING_HEADER},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"MMC3 multicart",		nullptr,		MIRRORING_MAPPER_HV},
+	{"DxROM (Tengen MIMIC-1, Namcot 118)", "Nintendo",	MIRRORING_HEADER},
+	{"Fudou Myouou Den",		"Taito",		MIRRORING_MAPPER_NAMCOT3425},
+	{"Street Fighter IV (unlicensed) (MMC3 clone)", nullptr, MIRRORING_MAPPER_HV},
+	{"J.Y. Company (MMC2/MMC4 clone)", "J.Y. Company",	MIRRORING_MAPPER_JY},
 
 	// Mappers 210-219
-	{"Namcot 175, 340",		"Namco"},
-	{"J.Y. Company (extended nametable control)", "J.Y. Company"},
-	{"BMC Super HiK 300-in-1",	nullptr},
-	{"(C)NROM-based multicart (same as 058)", nullptr},
-	{nullptr,			nullptr},
-	{"Sugar Softec (MMC3 clone)",	"Sugar Softec"},
-	{nullptr,			nullptr},
-	{nullptr,			nullptr},
-	{"Magic Floor",			"Homebrew"},
-	{"Kǎshèng A9461 (MMC3 clone)",	"Kǎshèng"},
+	{"Namcot 175, 340",		"Namco",		MIRRORING_MAPPER_HVAB /* see submapper */},
+	{"J.Y. Company (extended nametable control)", "J.Y. Company", MIRRORING_MAPPER_JY},
+	{"BMC Super HiK 300-in-1",	nullptr,		MIRRORING_MAPPER_HV},
+	{"(C)NROM-based multicart (same as 058)", nullptr,	MIRRORING_MAPPER_HV},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"Sugar Softec (MMC3 clone)",	"Sugar Softec",		MIRRORING_MAPPER_HV},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"Magic Floor",			"Homebrew",		MIRRORING_MAGICFLOOR},
+	{"Kǎshèng A9461 (MMC3 clone)",	"Kǎshèng",		MIRRORING_MAPPER_HV},
 
 	// Mappers 220-229
-	{"Summer Carnival '92 - Recca",	"Naxat Soft"},
-	{"NTDEC N625092",		"NTDEC"},
-	{"CTC-31 (VRC2 + 74xx)",	nullptr},
-	{nullptr,			nullptr},
-	{"Jncota KT-008",		"Jncota"},
-	{"Multicart",			nullptr},
-	{"Multicart",			nullptr},
-	{"Multicart",			nullptr},
-	{"Active Enterprises",		"Active Enterprises"},
-	{"BMC 31-IN-1",			nullptr},
+	{"Summer Carnival '92 - Recca",	"Naxat Soft",		MIRRORING_UNKNOWN /* TODO */},
+	{"NTDEC N625092",		"NTDEC",		MIRRORING_MAPPER_HV},
+	{"CTC-31 (VRC2 + 74xx)",	nullptr,		MIRRORING_MAPPER_HVAB},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"Jncota KT-008",		"Jncota",		MIRRORING_UNKNOWN /* TODO */},
+	{"Multicart",			nullptr,		MIRRORING_MAPPER_HV},
+	{"Multicart",			nullptr,		MIRRORING_MAPPER_HV},
+	{"Multicart",			nullptr,		MIRRORING_MAPPER_HV},
+	{"Active Enterprises",		"Active Enterprises",	MIRRORING_MAPPER_HV},
+	{"BMC 31-IN-1",			nullptr,		MIRRORING_MAPPER_HV},
 
 	// Mappers 230-239
-	{"Multicart",			nullptr},
-	{"Multicart",			nullptr},
-	{"Codemasters Quattro",		"Codemasters"},
-	{"Multicart",			nullptr},
-	{"Maxi 15 multicart",		nullptr},
-	{"Golden Game 150-in-1 multicart", nullptr},
-	{"Realtec 8155",		"Realtec"},
-	{"Teletubbies 420-in-1 multicart", nullptr},
-	{nullptr,			nullptr},
-	{nullptr,			nullptr},
+	{"Multicart",			nullptr,		MIRRORING_MAPPER_HV},
+	{"Multicart",			nullptr,		MIRRORING_MAPPER_HV},
+	{"Codemasters Quattro",		"Codemasters",		MIRRORING_HEADER},
+	{"Multicart",			nullptr,		MIRRORING_MAPPER_233},
+	{"Maxi 15 multicart",		nullptr,		MIRRORING_MAPPER_HV},
+	{"Golden Game 150-in-1 multicart", nullptr,		MIRRORING_MAPPER_235},
+	{"Realtec 8155",		"Realtec",		MIRRORING_MAPPER_HV},
+	{"Teletubbies 420-in-1 multicart", nullptr,		MIRRORING_MAPPER_HV},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
 
 	// Mappers 240-249
-	{"Multicart",			nullptr},
-	{"BNROM variant (similar to 034)", nullptr},
-	{"Unlicensed",			nullptr},
-	{"Sachen SA-020A",		"Sachen"},
-	{nullptr,			nullptr},
-	{"MMC3 clone",			nullptr},
-	{"Fēngshénbǎng: Fúmó Sān Tàizǐ (C&E)", "C&E"},
-	{nullptr,			nullptr},
-	{"Kǎshèng SFC-02B/-03/-004 (MMC3 clone) (incorrect assignment; should be 115)", "Kǎshèng"},
-	{nullptr,			nullptr},
+	{"Multicart",			nullptr,		MIRRORING_HEADER},
+	{"BNROM variant (similar to 034)", nullptr,		MIRRORING_HEADER},
+	{"Unlicensed",			nullptr,		MIRRORING_MAPPER_HV},
+	{"Sachen SA-020A",		"Sachen",		MIRRORING_MAPPER_SACHEN74LS374N},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"MMC3 clone",			nullptr,		MIRRORING_MAPPER_HV},
+	{"Fēngshénbǎng: Fúmó Sān Tàizǐ (C&E)", "C&E",		MIRRORING_HEADER},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"Kǎshèng SFC-02B/-03/-004 (MMC3 clone) (incorrect assignment; should be 115)", "Kǎshèng", MIRRORING_MAPPER_HV},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
 
 	// Mappers 250-255
-	{"Nitra (MMC3 clone)",		"Nitra"},
-	{nullptr,			nullptr},
-	{"Waixing - Sangokushi",	"Waixing"},
-	{"Dragon Ball Z: Kyōshū! Saiya-jin (VRC4 clone)", "Waixing"},
-	{"Pikachu Y2K of crypted ROMs",	nullptr},
-	{"110-in-1 multicart (same as 225)",		nullptr},
+	{"Nitra (MMC3 clone)",		"Nitra",		MIRRORING_MAPPER_HV},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"Waixing - Sangokushi",	"Waixing",		MIRRORING_MAPPER_HVAB},
+	{"Dragon Ball Z: Kyōshū! Saiya-jin (VRC4 clone)", "Waixing", MIRRORING_MAPPER_HVAB},
+	{"Pikachu Y2K of crypted ROMs",	nullptr,		MIRRORING_MAPPER_HV},
+	{"110-in-1 multicart (same as 225)", nullptr,		MIRRORING_MAPPER_HV},
 };
 
 /**
  * Mappers: NES 2.0 Plane 1 [256-511]
- * TODO: Add more fields:
- * - Programmable mirroring
- * - Extra VRAM for 4 screens
+ * TODO: Add mirroring info
  */
 const NESMappersPrivate::MapperEntry NESMappersPrivate::mappers_plane1[] = {
 	// Mappers 256-259
-	{"OneBus Famiclone",		nullptr},
-	{"UNIF PEC-586",		nullptr},	// From UNIF; reserved by FCEUX developers
-	{"UNIF 158B",			nullptr},	// From UNIF; reserved by FCEUX developers
-	{"UNIF F-15 (MMC3 multicart)",	nullptr},	// From UNIF; reserved by FCEUX developers
+	{"OneBus Famiclone",		nullptr,		MIRRORING_UNKNOWN},
+	{"UNIF PEC-586",		nullptr,		MIRRORING_UNKNOWN},	// From UNIF; reserved by FCEUX developers
+	{"UNIF 158B",			nullptr,		MIRRORING_UNKNOWN},	// From UNIF; reserved by FCEUX developers
+	{"UNIF F-15 (MMC3 multicart)",	nullptr,		MIRRORING_UNKNOWN},	// From UNIF; reserved by FCEUX developers
 
 	// Mappers 260-269
-	{"HP10xx/HP20xx multicart",	nullptr},
-	{"200-in-1 Elfland multicart",	nullptr},
-	{"Street Heroes (MMC3 clone)",	"Sachen"},
-	{"King of Fighters '97 (MMC3 clone)", nullptr},
-	{"Cony/Yoko Fighting Games",	"Cony/Yoko"},
-	{"T-262 multicart",		nullptr},
-	{"City Fighter IV",		nullptr},	// Hack of Master Fighter II
-	{"8-in-1 JY-119 multicart (MMC3 clone)", "J.Y. Company"},
-	{"SMD132/SMD133 (MMC3 clone)",	nullptr},
-	{"Multicart (MMC3 clone)",	nullptr},
+	{"HP10xx/HP20xx multicart",	nullptr,		MIRRORING_UNKNOWN},
+	{"200-in-1 Elfland multicart",	nullptr,		MIRRORING_UNKNOWN},
+	{"Street Heroes (MMC3 clone)",	"Sachen",		MIRRORING_UNKNOWN},
+	{"King of Fighters '97 (MMC3 clone)", nullptr,		MIRRORING_UNKNOWN},
+	{"Cony/Yoko Fighting Games",	"Cony/Yoko",		MIRRORING_UNKNOWN},
+	{"T-262 multicart",		nullptr,		MIRRORING_UNKNOWN},
+	{"City Fighter IV",		nullptr,		MIRRORING_UNKNOWN},	// Hack of Master Fighter II
+	{"8-in-1 JY-119 multicart (MMC3 clone)", "J.Y. Company", MIRRORING_UNKNOWN},
+	{"SMD132/SMD133 (MMC3 clone)",	nullptr,		MIRRORING_UNKNOWN},
+	{"Multicart (MMC3 clone)",	nullptr,		MIRRORING_UNKNOWN},
 
 	// Mappers 270-279
-	{"Game Prince RS-16",		nullptr},
-	{"TXC 4-in-1 multicart (MGC-026)", "TXC"},
-	{"Akumajō Special: Boku Dracula-kun (bootleg)", nullptr},
-	{"Gremlins 2 (bootleg)",	nullptr},
-	{"Cartridge Story multicart",	"RCM Group"},
-	{nullptr,			nullptr},
-	{nullptr,			nullptr},
-	{nullptr,			nullptr},
-	{nullptr,			nullptr},
-	{nullptr,			nullptr},
+	{"Game Prince RS-16",		nullptr,		MIRRORING_UNKNOWN},
+	{"TXC 4-in-1 multicart (MGC-026)", "TXC",		MIRRORING_UNKNOWN},
+	{"Akumajō Special: Boku Dracula-kun (bootleg)", nullptr, MIRRORING_UNKNOWN},
+	{"Gremlins 2 (bootleg)",	nullptr,		MIRRORING_UNKNOWN},
+	{"Cartridge Story multicart",	"RCM Group",		MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
 
 	// Mappers 280-289
-	{nullptr,			nullptr},
-	{"J.Y. Company Super HiK 3/4/5-in-1 multicart", "J.Y. Company"},
-	{"J.Y. Company multicart",	"J.Y. Company"},
-	{"Block Family 6-in-1/7-in-1 multicart", nullptr},
-	{"Drip",			"Homebrew"},
-	{"A65AS multicart",		nullptr},
-	{"Benshieng multicart",		"Benshieng"},
-	{"4-in-1 multicart (411120-C, 811120-C)", nullptr},
-	{"GKCX1 21-in-1 multicart",	nullptr},	// GoodNES 3.23b sets this to Mapper 133, which is wrong.
-	{"BMC-60311C",			nullptr},	// From UNIF
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"J.Y. Company Super HiK 3/4/5-in-1 multicart", "J.Y. Company", MIRRORING_UNKNOWN},
+	{"J.Y. Company multicart",	"J.Y. Company",		MIRRORING_UNKNOWN},
+	{"Block Family 6-in-1/7-in-1 multicart", nullptr,	MIRRORING_UNKNOWN},
+	{"Drip",			"Homebrew",		MIRRORING_UNKNOWN},
+	{"A65AS multicart",		nullptr,		MIRRORING_UNKNOWN},
+	{"Benshieng multicart",		"Benshieng",		MIRRORING_UNKNOWN},
+	{"4-in-1 multicart (411120-C, 811120-C)", nullptr,	MIRRORING_UNKNOWN},
+	{"GKCX1 21-in-1 multicart",	nullptr,		MIRRORING_UNKNOWN},	// GoodNES 3.23b sets this to Mapper 133, which is wrong.
+	{"BMC-60311C",			nullptr,		MIRRORING_UNKNOWN},	// From UNIF
 
 	// Mappers 290-299
-	{"Asder 20-in-1 multicart",	"Asder"},
-	{"Kǎshèng 2-in-1 multicart (MK6)", "Kǎshèng"},
-	{"Dragon Fighter (unlicensed)",	nullptr},
-	{"NewStar 12-in-1/76-in-1 multicart", nullptr},
-	{"T4A54A, WX-KB4K, BS-5652 (MMC3 clone) (same as 134)", nullptr},
-	{"J.Y. Company 13-in-1 multicart", "J.Y. Company"},
-	{"FC Pocket RS-20 / dreamGEAR My Arcade Gamer V", nullptr},
-	{"TXC 01-22110-000 multicart",	"TXC"},
-	{"Lethal Weapon (unlicensed) (VRC4 clone)", nullptr},
-	{"TXC 6-in-1 multicart (MGC-023)", "TXC"},
+	{"Asder 20-in-1 multicart",	"Asder",		MIRRORING_UNKNOWN},
+	{"Kǎshèng 2-in-1 multicart (MK6)", "Kǎshèng",		MIRRORING_UNKNOWN},
+	{"Dragon Fighter (unlicensed)",	nullptr,		MIRRORING_UNKNOWN},
+	{"NewStar 12-in-1/76-in-1 multicart", nullptr,		MIRRORING_UNKNOWN},
+	{"T4A54A, WX-KB4K, BS-5652 (MMC3 clone) (same as 134)", nullptr, MIRRORING_UNKNOWN},
+	{"J.Y. Company 13-in-1 multicart", "J.Y. Company",	MIRRORING_UNKNOWN},
+	{"FC Pocket RS-20 / dreamGEAR My Arcade Gamer V", nullptr, MIRRORING_UNKNOWN},
+	{"TXC 01-22110-000 multicart",	"TXC",			MIRRORING_UNKNOWN},
+	{"Lethal Weapon (unlicensed) (VRC4 clone)", nullptr,	MIRRORING_UNKNOWN},
+	{"TXC 6-in-1 multicart (MGC-023)", "TXC",		MIRRORING_UNKNOWN},
 
 	// Mappers 300-309
-	{"Golden 190-in-1 multicart",	nullptr},
-	{"GG1 multicart",		nullptr},
-	{"Gyruss (FDS conversion)",	"Kaiser"},
-	{"Almana no Kiseki (FDS conversion)", "Kaiser"},
-	{"FDS conversion",		"Whirlwind Manu"},
-	{"Dracula II: Noroi no Fūin (FDS conversion)", "Kaiser"},
-	{"Exciting Basket (FDS conversion)", "Kaiser"},
-	{"Metroid (FDS conversion)",	"Kaiser"},
-	{"Batman (Sunsoft) (bootleg) (VRC2 clone)", nullptr},
-	{"Ai Senshi Nicol (FDS conversion)", "Whirlwind Manu"},
+	{"Golden 190-in-1 multicart",	nullptr,		MIRRORING_UNKNOWN},
+	{"GG1 multicart",		nullptr,		MIRRORING_UNKNOWN},
+	{"Gyruss (FDS conversion)",	"Kaiser",		MIRRORING_UNKNOWN},
+	{"Almana no Kiseki (FDS conversion)", "Kaiser",		MIRRORING_UNKNOWN},
+	{"FDS conversion",		"Whirlwind Manu",	MIRRORING_UNKNOWN},
+	{"Dracula II: Noroi no Fūin (FDS conversion)", "Kaiser", MIRRORING_UNKNOWN},
+	{"Exciting Basket (FDS conversion)", "Kaiser",		MIRRORING_UNKNOWN},
+	{"Metroid (FDS conversion)",	"Kaiser",		MIRRORING_UNKNOWN},
+	{"Batman (Sunsoft) (bootleg) (VRC2 clone)", nullptr,	MIRRORING_UNKNOWN},
+	{"Ai Senshi Nicol (FDS conversion)", "Whirlwind Manu",	MIRRORING_UNKNOWN},
 
 	// Mappers 310-319
-	{"Monty no Doki Doki Daisassō (FDS conversion) (same as 125)", "Whirlwind Manu"},
-	{nullptr,			nullptr},
-	{"Highway Star (bootleg)",	"Kaiser"},
-	{"Reset-based multicart (MMC3)", nullptr},
-	{"Y2K multicart",		nullptr},
-	{"820732C- or 830134C- multicart", nullptr},
-	{nullptr,			nullptr},
-	{nullptr,			nullptr},
-	{nullptr,			nullptr},
-	{"HP-898F, KD-7/9-E multicart",	nullptr},
+	{"Monty no Doki Doki Daisassō (FDS conversion) (same as 125)", "Whirlwind Manu", MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"Highway Star (bootleg)",	"Kaiser",		MIRRORING_UNKNOWN},
+	{"Reset-based multicart (MMC3)", nullptr,		MIRRORING_UNKNOWN},
+	{"Y2K multicart",		nullptr,		MIRRORING_UNKNOWN},
+	{"820732C- or 830134C- multicart", nullptr,		MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"HP-898F, KD-7/9-E multicart",	nullptr,		MIRRORING_UNKNOWN},
 
 	// Mappers 320-329
-	{"Super HiK 6-in-1 A-030 multicart", nullptr},
-	{nullptr,			nullptr},
-	{"35-in-1 (K-3033) multicart",	nullptr},
-	{"Farid's homebrew 8-in-1 SLROM multicart", nullptr},	// Homebrew
-	{"Farid's homebrew 8-in-1 UNROM multicart", nullptr},	// Homebrew
-	{"Super Mali Splash Bomb (bootleg)", nullptr},
-	{"Contra/Gryzor (bootleg)",	nullptr},
-	{"6-in-1 multicart",		nullptr},
-	{"Test Ver. 1.01 Dlya Proverki TV Pristavok test cartridge", nullptr},
-	{"Education Computer 2000",	nullptr},
+	{"Super HiK 6-in-1 A-030 multicart", nullptr,		MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"35-in-1 (K-3033) multicart",	nullptr,		MIRRORING_UNKNOWN},
+	{"Farid's homebrew 8-in-1 SLROM multicart", nullptr,	MIRRORING_UNKNOWN},	// Homebrew
+	{"Farid's homebrew 8-in-1 UNROM multicart", nullptr,	MIRRORING_UNKNOWN},	// Homebrew
+	{"Super Mali Splash Bomb (bootleg)", nullptr,		MIRRORING_UNKNOWN},
+	{"Contra/Gryzor (bootleg)",	nullptr,		MIRRORING_UNKNOWN},
+	{"6-in-1 multicart",		nullptr,		MIRRORING_UNKNOWN},
+	{"Test Ver. 1.01 Dlya Proverki TV Pristavok test cartridge", nullptr, MIRRORING_UNKNOWN},
+	{"Education Computer 2000",	nullptr,		MIRRORING_UNKNOWN},
 
 	// Mappers 330-339
-	{"Sangokushi II: Haō no Tairiku (bootleg)", nullptr},
-	{"7-in-1 (NS03) multicart",	nullptr},
-	{"Super 40-in-1 multicart",	nullptr},
-	{"New Star Super 8-in-1 multicart", "New Star"},
-	{"5/20-in-1 1993 Copyright multicart", nullptr},
-	{"10-in-1 multicart",		nullptr},
-	{"11-in-1 multicart",		nullptr},
-	{"12-in-1 Game Card multicart",	nullptr},
-	{"16-in-1, 200/300/600/1000-in-1 multicart", nullptr},
-	{"21-in-1 multicart",		nullptr},
+	{"Sangokushi II: Haō no Tairiku (bootleg)", nullptr,	MIRRORING_UNKNOWN},
+	{"7-in-1 (NS03) multicart",	nullptr,		MIRRORING_UNKNOWN},
+	{"Super 40-in-1 multicart",	nullptr,		MIRRORING_UNKNOWN},
+	{"New Star Super 8-in-1 multicart", "New Star",		MIRRORING_UNKNOWN},
+	{"5/20-in-1 1993 Copyright multicart", nullptr,		MIRRORING_UNKNOWN},
+	{"10-in-1 multicart",		nullptr,		MIRRORING_UNKNOWN},
+	{"11-in-1 multicart",		nullptr,		MIRRORING_UNKNOWN},
+	{"12-in-1 Game Card multicart",	nullptr,		MIRRORING_UNKNOWN},
+	{"16-in-1, 200/300/600/1000-in-1 multicart", nullptr,	MIRRORING_UNKNOWN},
+	{"21-in-1 multicart",		nullptr,		MIRRORING_UNKNOWN},
 
 	// Mappers 340-349
-	{"35-in-1 multicart",		nullptr},
-	{"Simple 4-in-1 multicart",	nullptr},
-	{"COOLGIRL multicart (Homebrew)", "Homebrew"},	// Homebrew
-	{nullptr,			nullptr},
-	{"Kuai Da Jin Ka Zhong Ji Tiao Zhan 3-in-1 multicart", nullptr},
-	{"New Star 6-in-1 Game Cartridge multicart", "New Star"},
-	{"Zanac (FDS conversion)",	"Kaiser"},
-	{"Yume Koujou: Doki Doki Panic (FDS conversion)", "Kaiser"},
-	{"830118C",			nullptr},
-	{"1994 Super HIK 14-in-1 (G-136) multicart", nullptr},
+	{"35-in-1 multicart",		nullptr,		MIRRORING_UNKNOWN},
+	{"Simple 4-in-1 multicart",	nullptr,		MIRRORING_UNKNOWN},
+	{"COOLGIRL multicart (Homebrew)", "Homebrew",		MIRRORING_UNKNOWN},	// Homebrew
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"Kuai Da Jin Ka Zhong Ji Tiao Zhan 3-in-1 multicart", nullptr, MIRRORING_UNKNOWN},
+	{"New Star 6-in-1 Game Cartridge multicart", "New Star", MIRRORING_UNKNOWN},
+	{"Zanac (FDS conversion)",	"Kaiser",		MIRRORING_UNKNOWN},
+	{"Yume Koujou: Doki Doki Panic (FDS conversion)", "Kaiser", MIRRORING_UNKNOWN},
+	{"830118C",			nullptr,		MIRRORING_UNKNOWN},
+	{"1994 Super HIK 14-in-1 (G-136) multicart", nullptr,	MIRRORING_UNKNOWN},
 
 	// Mappers 350-359
-	{"Super 15-in-1 Game Card multicart", nullptr},
-	{"9-in-1 multicart",		"J.Y. Company / Techline"},
-	{nullptr,			nullptr},
-	{"92 Super Mario Family multicart", nullptr},
-	{"250-in-1 multicart",		nullptr},
-	{"黃信維 3D-BLOCK",		nullptr},
-	{"7-in-1 Rockman (JY-208)",	"J.Y. Company"},
-	{"4-in-1 (4602) multicart",	"Bit Corp."},
-	{"J.Y. Company multicart",	"J.Y. Company"},
-	{"SB-5013 / GCL8050 / 841242C multicart", nullptr},
+	{"Super 15-in-1 Game Card multicart", nullptr,		MIRRORING_UNKNOWN},
+	{"9-in-1 multicart",		"J.Y. Company / Techline", MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"92 Super Mario Family multicart", nullptr,		MIRRORING_UNKNOWN},
+	{"250-in-1 multicart",		nullptr,		MIRRORING_UNKNOWN},
+	{"黃信維 3D-BLOCK",		nullptr,		MIRRORING_UNKNOWN},
+	{"7-in-1 Rockman (JY-208)",	"J.Y. Company",		MIRRORING_UNKNOWN},
+	{"4-in-1 (4602) multicart",	"Bit Corp.",		MIRRORING_UNKNOWN},
+	{"J.Y. Company multicart",	"J.Y. Company",		MIRRORING_UNKNOWN},
+	{"SB-5013 / GCL8050 / 841242C multicart", nullptr,	MIRRORING_UNKNOWN},
 
 	// Mappers 360-369
-	{"31-in-1 (3150) multicart",	"Bit Corp."},
-	{"YY841101C multicart (MMC3 clone)", "J.Y. Company"},
-	{"830506C multicart (VRC4f clone)", "J.Y. Company"},
-	{"J.Y. Company multicart",	"J.Y. Company"},
-	{"JY830832C multicart",		"J.Y. Company"},
-	{"Asder PC-95 educational computer", "Asder"},
-	{"GN-45 multicart (MMC3 clone)", nullptr},
-	{"7-in-1 multicart",		nullptr},
-	{"Super Mario Bros. 2 (J) (FDS conversion)", "YUNG-08"},
-	{"N49C-300",			nullptr},
+	{"31-in-1 (3150) multicart",	"Bit Corp.",		MIRRORING_UNKNOWN},
+	{"YY841101C multicart (MMC3 clone)", "J.Y. Company",	MIRRORING_UNKNOWN},
+	{"830506C multicart (VRC4f clone)", "J.Y. Company",	MIRRORING_UNKNOWN},
+	{"J.Y. Company multicart",	"J.Y. Company",		MIRRORING_UNKNOWN},
+	{"JY830832C multicart",		"J.Y. Company",		MIRRORING_UNKNOWN},
+	{"Asder PC-95 educational computer", "Asder",		MIRRORING_UNKNOWN},
+	{"GN-45 multicart (MMC3 clone)", nullptr,		MIRRORING_UNKNOWN},
+	{"7-in-1 multicart",		nullptr,		MIRRORING_UNKNOWN},
+	{"Super Mario Bros. 2 (J) (FDS conversion)", "YUNG-08",	MIRRORING_UNKNOWN},
+	{"N49C-300",			nullptr,		MIRRORING_UNKNOWN},
 
 	// Mappers 370-379
-	{"F600",			nullptr},
-	{"Spanish PEC-586 home computer cartridge", "Dongda"},
-	{"Rockman 1-6 (SFC-12) multicart", nullptr},
-	{"Super 4-in-1 (SFC-13) multicart", nullptr},
-	{"Reset-based MMC1 multicart",	nullptr},
-	{"135-in-1 (U)NROM multicart",	nullptr},
-	{"YY841155C multicart",		"J.Y. Company"},
-	{"8-in-1 AxROM/UNROM multicart", nullptr},
-	{"35-in-1 NROM multicart",	nullptr},
+	{"F600",			nullptr,		MIRRORING_UNKNOWN},
+	{"Spanish PEC-586 home computer cartridge", "Dongda",	MIRRORING_UNKNOWN},
+	{"Rockman 1-6 (SFC-12) multicart", nullptr,		MIRRORING_UNKNOWN},
+	{"Super 4-in-1 (SFC-13) multicart", nullptr,		MIRRORING_UNKNOWN},
+	{"Reset-based MMC1 multicart",	nullptr,		MIRRORING_UNKNOWN},
+	{"135-in-1 (U)NROM multicart",	nullptr,		MIRRORING_UNKNOWN},
+	{"YY841155C multicart",		"J.Y. Company",		MIRRORING_UNKNOWN},
+	{"8-in-1 AxROM/UNROM multicart", nullptr,		MIRRORING_UNKNOWN},
+	{"35-in-1 NROM multicart",	nullptr,		MIRRORING_UNKNOWN},
 
 	// Mappers 380-389
-	{"970630C",			nullptr},
-	{"KN-42",			nullptr},
-	{"830928C",			nullptr},
-	{"YY840708C (MMC3 clone)",	"J.Y. Company"},
-	{"L1A16 (VRC4e clone)",		nullptr},
-	{"NTDEC 2779",			"NTDEC"},
-	{"YY860729C",			"J.Y. Company"},
-	{"YY850735C / YY850817C",	"J.Y. Company"},
-	{"YY841145C / YY850835C",	"J.Y. Company"},
-	{"Caltron 9-in-1 multicart",	"Caltron"},
+	{"970630C",			nullptr,		MIRRORING_UNKNOWN},
+	{"KN-42",			nullptr,		MIRRORING_UNKNOWN},
+	{"830928C",			nullptr,		MIRRORING_UNKNOWN},
+	{"YY840708C (MMC3 clone)",	"J.Y. Company",		MIRRORING_UNKNOWN},
+	{"L1A16 (VRC4e clone)",		nullptr,		MIRRORING_UNKNOWN},
+	{"NTDEC 2779",			"NTDEC",		MIRRORING_UNKNOWN},
+	{"YY860729C",			"J.Y. Company",		MIRRORING_UNKNOWN},
+	{"YY850735C / YY850817C",	"J.Y. Company",		MIRRORING_UNKNOWN},
+	{"YY841145C / YY850835C",	"J.Y. Company",		MIRRORING_UNKNOWN},
+	{"Caltron 9-in-1 multicart",	"Caltron",		MIRRORING_UNKNOWN},
 
 	// Mappers 390-391
-	{"Realtec 8031",		"Realtec"},
-	{"NC7000M (MMC3 clone)",	nullptr},
+	{"Realtec 8031",		"Realtec",		MIRRORING_UNKNOWN},
+	{"NC7000M (MMC3 clone)",	nullptr,		MIRRORING_UNKNOWN},
 };
 
 /**
  * Mappers: NES 2.0 Plane 2 [512-767]
- * TODO: Add more fields:
- * - Programmable mirroring
- * - Extra VRAM for 4 screens
+ * TODO: Add mirroring info
  */
 const NESMappersPrivate::MapperEntry NESMappersPrivate::mappers_plane2[] = {
 	// Mappers 512-519
-	{"Zhōngguó Dàhēng",		"Sachen"},
-	{"Měi Shàonǚ Mèng Gōngchǎng III", "Sachen"},
-	{"Subor Karaoke",		"Subor"},
-	{"Family Noraebang",		nullptr},
-	{"Brilliant Com Cocoma Pack",	"EduBank"},
-	{"Kkachi-wa Nolae Chingu",	nullptr},
-	{"Subor multicart",		"Subor"},
-	{"UNL-EH8813A",			nullptr},
+	{"Zhōngguó Dàhēng",		"Sachen",		MIRRORING_UNKNOWN},
+	{"Měi Shàonǚ Mèng Gōngchǎng III", "Sachen",		MIRRORING_UNKNOWN},
+	{"Subor Karaoke",		"Subor",		MIRRORING_UNKNOWN},
+	{"Family Noraebang",		nullptr,		MIRRORING_UNKNOWN},
+	{"Brilliant Com Cocoma Pack",	"EduBank",		MIRRORING_UNKNOWN},
+	{"Kkachi-wa Nolae Chingu",	nullptr,		MIRRORING_UNKNOWN},
+	{"Subor multicart",		"Subor",		MIRRORING_UNKNOWN},
+	{"UNL-EH8813A",			nullptr,		MIRRORING_UNKNOWN},
 
 	// Mappers 520-529
-	{"2-in-1 Datach multicart (VRC4e clone)", nullptr},
-	{"Korean Igo",			nullptr},
-	{"Fūun Shōrinken (FDS conversion)", "Whirlwind Manu"},
-	{"Fēngshénbǎng: Fúmó Sān Tàizǐ (Jncota)", "Jncota"},
-	{"The Lord of King (Jaleco) (bootleg)", nullptr},
-	{"UNL-KS7021A (VRC2b clone)",	"Kaiser"},
-	{"Sangokushi: Chūgen no Hasha (bootleg)", nullptr},
-	{"Fudō Myōō Den (bootleg) (VRC2b clone)", nullptr},
-	{"1995 New Series Super 2-in-1 multicart", nullptr},
-	{"Datach Dragon Ball Z (bootleg) (VRC4e clone)", nullptr},
+	{"2-in-1 Datach multicart (VRC4e clone)", nullptr,	MIRRORING_UNKNOWN},
+	{"Korean Igo",			nullptr,		MIRRORING_UNKNOWN},
+	{"Fūun Shōrinken (FDS conversion)", "Whirlwind Manu",	MIRRORING_UNKNOWN},
+	{"Fēngshénbǎng: Fúmó Sān Tàizǐ (Jncota)", "Jncota",	MIRRORING_UNKNOWN},
+	{"The Lord of King (Jaleco) (bootleg)", nullptr,	MIRRORING_UNKNOWN},
+	{"UNL-KS7021A (VRC2b clone)",	"Kaiser",		MIRRORING_UNKNOWN},
+	{"Sangokushi: Chūgen no Hasha (bootleg)", nullptr,	MIRRORING_UNKNOWN},
+	{"Fudō Myōō Den (bootleg) (VRC2b clone)", nullptr,	MIRRORING_UNKNOWN},
+	{"1995 New Series Super 2-in-1 multicart", nullptr,	MIRRORING_UNKNOWN},
+	{"Datach Dragon Ball Z (bootleg) (VRC4e clone)", nullptr, MIRRORING_UNKNOWN},
 
 	// Mappers 530-539
-	{"Super Mario Bros. Pocker Mali (VRC4f clone)", nullptr},
-	{nullptr,			nullptr},
-	{nullptr,			nullptr},
-	{"Sachen 3014",			"Sachen"},
-	{"2-in-1 Sudoku/Gomoku (NJ064) (MMC3 clone)", nullptr},
-	{"Nazo no Murasamejō (FDS conversion)", "Whirlwind Manu"},
-	{"Waixing FS303 (MMC3 clone) (same as 195)",	"Waixing"},
-	{"Waixing FS303 (MMC3 clone) (same as 195)",	"Waixing"},
-	{"60-1064-16L",			nullptr},
-	{"Kid Icarus (FDS conversion)",	nullptr},
+	{"Super Mario Bros. Pocker Mali (VRC4f clone)", nullptr, MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"Sachen 3014",			"Sachen",		MIRRORING_UNKNOWN},
+	{"2-in-1 Sudoku/Gomoku (NJ064) (MMC3 clone)", nullptr,	MIRRORING_UNKNOWN},
+	{"Nazo no Murasamejō (FDS conversion)", "Whirlwind Manu", MIRRORING_UNKNOWN},
+	{"Waixing FS303 (MMC3 clone) (same as 195)",	"Waixing", MIRRORING_UNKNOWN},
+	{"Waixing FS303 (MMC3 clone) (same as 195)",	"Waixing", MIRRORING_UNKNOWN},
+	{"60-1064-16L",			nullptr,		MIRRORING_UNKNOWN},
+	{"Kid Icarus (FDS conversion)",	nullptr,		MIRRORING_UNKNOWN},
 
 	// Mappers 540-549
-	{"Master Fighter VI' hack (variant of 359)", nullptr},
-	{"LittleCom 160-in-1 multicart", nullptr},	// Is LittleCom the company name?
-	{"World Hero hack (VRC4 clone)", nullptr},
-	{"5-in-1 (CH-501) multicart (MMC1 clone)", nullptr},
-	{"Waixing FS306",		"Waixing"},
-	{nullptr,			nullptr},
-	{nullptr,			nullptr},
-	{"Konami QTa adapter (VRC5)",	"Konami"},
-	{"CTC-15",			"Co Tung Co."},
-	{nullptr,			nullptr},
+	{"Master Fighter VI' hack (variant of 359)", nullptr,	MIRRORING_UNKNOWN},
+	{"LittleCom 160-in-1 multicart", nullptr,		MIRRORING_UNKNOWN},	// Is LittleCom the company name?
+	{"World Hero hack (VRC4 clone)", nullptr,		MIRRORING_UNKNOWN},
+	{"5-in-1 (CH-501) multicart (MMC1 clone)", nullptr,	MIRRORING_UNKNOWN},
+	{"Waixing FS306",		"Waixing",		MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"Konami QTa adapter (VRC5)",	"Konami",		MIRRORING_UNKNOWN},
+	{"CTC-15",			"Co Tung Co.",		MIRRORING_UNKNOWN},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
 
 	// Mappers 550-552
-	{nullptr,			nullptr},
-	{"Jncota RPG re-release (variant of 178)", "Jncota"},
-	{"Taito X1-017 (correct PRG ROM bank ordering)", "Taito"},
+	{nullptr,			nullptr,		MIRRORING_UNKNOWN},
+	{"Jncota RPG re-release (variant of 178)", "Jncota",	MIRRORING_UNKNOWN},
+	{"Taito X1-017 (correct PRG ROM bank ordering)", "Taito", MIRRORING_UNKNOWN},
 };
 
 /** Submappers. **/
 
 // Mapper 001: MMC1
 const struct NESMappersPrivate::SubmapperInfo NESMappersPrivate::mmc1_submappers[] = {
-	{1, 0,   1, "SUROM"},
-	{2, 0,   1, "SOROM"},
-	{3, 0, 155, "MMC1A"},
-	{4, 0,   1, "SXROM"},
-	{5, 0,   0, "SEROM, SHROM, SH1ROM"},
+	{1, 0,   1, "SUROM", MIRRORING_UNKNOWN},
+	{2, 0,   1, "SOROM", MIRRORING_UNKNOWN},
+	{3, 0, 155, "MMC1A", MIRRORING_UNKNOWN},
+	{4, 0,   1, "SXROM", MIRRORING_UNKNOWN},
+	{5, 0,   0, "SEROM, SHROM, SH1ROM", MIRRORING_UNKNOWN},
 };
 
 // Discrete logic mappers: UxROM (002), CNROM (003), AxROM (007)
 const struct NESMappersPrivate::SubmapperInfo NESMappersPrivate::discrete_logic_submappers[] = {
-	{0, 0,   0, "Bus conflicts are unspecified"},
-	{1, 0,   0, "Bus conflicts do not occur"},
-	{2, 0,   0, "Bus conflicts occur, resulting in: bus AND rom"},
+	{0, 0,   0, "Bus conflicts are unspecified", MIRRORING_UNKNOWN},
+	{1, 0,   0, "Bus conflicts do not occur", MIRRORING_UNKNOWN},
+	{2, 0,   0, "Bus conflicts occur, resulting in: bus AND rom", MIRRORING_UNKNOWN},
 };
 
 // Mapper 004: MMC3
 const struct NESMappersPrivate::SubmapperInfo NESMappersPrivate::mmc3_submappers[] = {
-	{0, 0,      0, "MMC3C"},
-	{1, 0,      0, "MMC6"},
-	{2, 0, 0xFFFF, "MMC3C with hard-wired mirroring"},
-	{3, 0,      0, "MC-ACC"},
-	{4, 0,      0, "MMC3A"},
+	{0, 0,      0, "MMC3C", MIRRORING_UNKNOWN},
+	{1, 0,      0, "MMC6", MIRRORING_UNKNOWN},
+	{2, 0, 0xFFFF, "MMC3C with hard-wired mirroring", MIRRORING_UNKNOWN},
+	{3, 0,      0, "MC-ACC", MIRRORING_UNKNOWN},
+	{4, 0,      0, "MMC3A", MIRRORING_UNKNOWN},
 };
 
 // Mapper 016: Bandai FCG-x
 const struct NESMappersPrivate::SubmapperInfo NESMappersPrivate::bandai_fcgx_submappers[] = {
-	{1, 0, 159, "LZ93D50 with 24C01"},
-	{2, 0, 157, "Datach Joint ROM System"},
-	{3, 0, 153, "8 KiB of WRAM instead of serial EEPROM"},
-	{4, 0,   0, "FCG-1/2"},
-	{5, 0,   0, "LZ93D50 with optional 24C02"},
+	{1, 0, 159, "LZ93D50 with 24C01", MIRRORING_UNKNOWN},
+	{2, 0, 157, "Datach Joint ROM System", MIRRORING_UNKNOWN},
+	{3, 0, 153, "8 KiB of WRAM instead of serial EEPROM", MIRRORING_UNKNOWN},
+	{4, 0,   0, "FCG-1/2", MIRRORING_UNKNOWN},
+	{5, 0,   0, "LZ93D50 with optional 24C02", MIRRORING_UNKNOWN},
 };
 
 // Mapper 019: Namco 129, 163
 const struct NESMappersPrivate::SubmapperInfo NESMappersPrivate::namco_129_164_submappers[] = {
-	{0, 0,   0, "Expansion sound volume unspecified"},
-	{1, 0,  19, "Internal RAM battery-backed; no expansion sound"},
-	{2, 0,   0, "No expansion sound"},
-	{3, 0,   0, "N163 expansion sound: 11.0-13.0 dB louder than NES APU"},
-	{4, 0,   0, "N163 expansion sound: 16.0-17.0 dB louder than NES APU"},
-	{5, 0,   0, "N163 expansion sound: 18.0-19.5 dB louder than NES APU"},
+	{0, 0,   0, "Expansion sound volume unspecified", MIRRORING_UNKNOWN},
+	{1, 0,  19, "Internal RAM battery-backed; no expansion sound", MIRRORING_UNKNOWN},
+	{2, 0,   0, "No expansion sound", MIRRORING_UNKNOWN},
+	{3, 0,   0, "N163 expansion sound: 11.0-13.0 dB louder than NES APU", MIRRORING_UNKNOWN},
+	{4, 0,   0, "N163 expansion sound: 16.0-17.0 dB louder than NES APU", MIRRORING_UNKNOWN},
+	{5, 0,   0, "N163 expansion sound: 18.0-19.5 dB louder than NES APU", MIRRORING_UNKNOWN},
 };
 
 // Mapper 021: Konami VRC4c, VRC4c
 const struct NESMappersPrivate::SubmapperInfo NESMappersPrivate::vrc4a_vrc4c_submappers[] = {
-	{1, 0,   0, "VRC4a"},
-	{2, 0,   0, "VRC4c"},
+	{1, 0,   0, "VRC4a", MIRRORING_UNKNOWN},
+	{2, 0,   0, "VRC4c", MIRRORING_UNKNOWN},
 };
 
 // Mapper 023: Konami VRC4e, VRC4f, VRC2b
 const struct NESMappersPrivate::SubmapperInfo NESMappersPrivate::vrc4ef_vrc2b_submappers[] = {
-	{1, 0,   0, "VRC4f"},
-	{2, 0,   0, "VRC4e"},
-	{3, 0,   0, "VRC2b"},
+	{1, 0,   0, "VRC4f", MIRRORING_UNKNOWN},
+	{2, 0,   0, "VRC4e", MIRRORING_UNKNOWN},
+	{3, 0,   0, "VRC2b", MIRRORING_UNKNOWN},
 };
 
 // Mapper 025: Konami VRC4b, VRC4d, VRC2c
 const struct NESMappersPrivate::SubmapperInfo NESMappersPrivate::vrc4bd_vrc2c_submappers[] = {
-	{1, 0,   0, "VRC4b"},
-	{2, 0,   0, "VRC4d"},
-	{3, 0,   0, "VRC2c"},
+	{1, 0,   0, "VRC4b", MIRRORING_UNKNOWN},
+	{2, 0,   0, "VRC4d", MIRRORING_UNKNOWN},
+	{3, 0,   0, "VRC2c", MIRRORING_UNKNOWN},
 };
 
 // Mapper 032: Irem G101
 const struct NESMappersPrivate::SubmapperInfo NESMappersPrivate::irem_g101_submappers[] = {
-	// TODO: Some field to indicate mirroring override?
-	{0, 0,   0, "Programmable mirroring"},
-	{1, 0,   0, "Fixed one-screen mirroring"},
+	{0, 0,   0, "Programmable mirroring", MIRRORING_UNKNOWN},
+	{1, 0,   0, "Fixed one-screen mirroring", MIRRORING_1SCREEN_B},
 };
 
 // Mapper 034: BNROM / NINA-001
 // TODO: Distinguish between these two for iNES ROMs.
 const struct NESMappersPrivate::SubmapperInfo NESMappersPrivate::bnrom_nina001_submappers[] = {
-	{1, 0,   0, "NINA-001"},
-	{2, 0,   0, "BNROM"},
+	{1, 0,   0, "NINA-001", MIRRORING_UNKNOWN},
+	{2, 0,   0, "BNROM", MIRRORING_UNKNOWN},
 };
 
 // Mapper 068: Sunsoft-4
 const struct NESMappersPrivate::SubmapperInfo NESMappersPrivate::sunsoft4_submappers[] = {
-	{1, 0,   0, "Dual Cartridge System (NTB-ROM)"},
+	{1, 0,   0, "Dual Cartridge System (NTB-ROM)", MIRRORING_UNKNOWN},
 };
 
 // Mapper 071: Codemasters
 const struct NESMappersPrivate::SubmapperInfo NESMappersPrivate::codemasters_submappers[] = {
-	{1, 0,   0, "Programmable one-screen mirroring (Fire Hawk)"},
+	{1, 0,   0, "Programmable one-screen mirroring (Fire Hawk)", MIRRORING_MAPPER_AB},
 };
 
 // Mapper 078: Cosmo Carrier / Holy Diver
 const struct NESMappersPrivate::SubmapperInfo NESMappersPrivate::mapper078_submappers[] = {
-	{1, 0,      0, "Programmable one-screen mirroring (Uchuusen: Cosmo Carrier)"},
-	{2, 0, 0xFFFF,  "Fixed vertical mirroring + WRAM"},
-	{3, 0,      0, "Programmable H/V mirroring (Holy Diver)"},
+	{1, 0,      0, "Programmable one-screen mirroring (Uchuusen: Cosmo Carrier)", MIRRORING_MAPPER_AB},
+	{2, 0, 0xFFFF,  "Fixed vertical mirroring + WRAM", MIRRORING_UNKNOWN},
+	{3, 0,      0, "Programmable H/V mirroring (Holy Diver)", MIRRORING_MAPPER_HV},
 };
 
 // Mapper 083: Cony/Yoko
 const struct NESMappersPrivate::SubmapperInfo NESMappersPrivate::cony_yoko_submappers[] = {
-	{0, 0,   0, "1 KiB CHR-ROM banking, no WRAM"},
-	{1, 0,   0, "2 KiB CHR-ROM banking, no WRAM"},
-	{2, 0,   0, "1 KiB CHR-ROM banking, 32 KiB banked WRAM"},
+	{0, 0,   0, "1 KiB CHR-ROM banking, no WRAM", MIRRORING_UNKNOWN},
+	{1, 0,   0, "2 KiB CHR-ROM banking, no WRAM", MIRRORING_UNKNOWN},
+	{2, 0,   0, "1 KiB CHR-ROM banking, 32 KiB banked WRAM", MIRRORING_UNKNOWN},
 };
 
 // Mapper 114: Sugar Softec/Hosenkan
 const struct NESMappersPrivate::SubmapperInfo NESMappersPrivate::mapper114_submappers[] = {
-	{0, 0,   0, "MMC3 registers: 0,3,1,5,6,7,2,4"},
-	{1, 0,   0, "MMC3 registers: 0,2,5,3,6,1,7,4"},
+	{0, 0,   0, "MMC3 registers: 0,3,1,5,6,7,2,4", MIRRORING_UNKNOWN},
+	{1, 0,   0, "MMC3 registers: 0,2,5,3,6,1,7,4", MIRRORING_UNKNOWN},
 };
 
 // Mapper 197: Kǎshèng (MMC3 clone)
 const struct NESMappersPrivate::SubmapperInfo NESMappersPrivate::mapper197_submappers[] = {
-	{0, 0,   0, "Super Fighter III (PRG-ROM CRC32 0xC333F621)"},
-	{1, 0,   0, "Super Fighter III (PRG-ROM CRC32 0x2091BEB2)"},
-	{2, 0,   0, "Mortal Kombat III Special"},
-	{3, 0,   0, "1995 Super 2-in-1"},
+	{0, 0,   0, "Super Fighter III (PRG-ROM CRC32 0xC333F621)", MIRRORING_UNKNOWN},
+	{1, 0,   0, "Super Fighter III (PRG-ROM CRC32 0x2091BEB2)", MIRRORING_UNKNOWN},
+	{2, 0,   0, "Mortal Kombat III Special", MIRRORING_UNKNOWN},
+	{3, 0,   0, "1995 Super 2-in-1", MIRRORING_UNKNOWN},
 };
 
 // Mapper 210: Namcot 175, 340
 const struct NESMappersPrivate::SubmapperInfo NESMappersPrivate::namcot_175_340_submappers[] = {
-	{1, 0,   0, "Namcot 175 (fixed mirroring)"},
-	{2, 0,   0, "Namcot 340 (programmable mirroring)"},
+	{1, 0,   0, "Namcot 175 (fixed mirroring)",        MIRRORING_HEADER},
+	{2, 0,   0, "Namcot 340 (programmable mirroring)", MIRRORING_MAPPER_HVAB},
 };
 
 // Mapper 215: Sugar Softec
 const struct NESMappersPrivate::SubmapperInfo NESMappersPrivate::sugar_softec_submappers[] = {
-	{0, 0,   0, "UNL-8237"},
-	{1, 0,   0, "UNL-8237A"},
+	{0, 0,   0, "UNL-8237", MIRRORING_UNKNOWN},
+	{1, 0,   0, "UNL-8237A", MIRRORING_UNKNOWN},
 };
 
 // Mapper 232: Codemasters Quattro
 const struct NESMappersPrivate::SubmapperInfo NESMappersPrivate::quattro_submappers[] = {
-	{1, 0,   0, "Aladdin Deck Enhancer"},
+	{1, 0,   0, "Aladdin Deck Enhancer", MIRRORING_UNKNOWN},
 };
 
 // Mapper 256: OneBus Famiclones
 const struct NESMappersPrivate::SubmapperInfo NESMappersPrivate::onebus_submappers[] = {
-	{ 1, 0,   0, "Waixing VT03"},
-	{ 2, 0,   0, "Power Joy Supermax"},
-	{ 3, 0,   0, "Zechess/Hummer Team"},
-	{ 4, 0,   0, "Sports Game 69-in-1"},
-	{ 5, 0,   0, "Waixing VT02"},
-	{14, 0,   0, "Karaoto"},
-	{15, 0,   0, "Jungletac"},
+	{ 1, 0,   0, "Waixing VT03", MIRRORING_UNKNOWN},
+	{ 2, 0,   0, "Power Joy Supermax", MIRRORING_UNKNOWN},
+	{ 3, 0,   0, "Zechess/Hummer Team", MIRRORING_UNKNOWN},
+	{ 4, 0,   0, "Sports Game 69-in-1", MIRRORING_UNKNOWN},
+	{ 5, 0,   0, "Waixing VT02", MIRRORING_UNKNOWN},
+	{14, 0,   0, "Karaoto", MIRRORING_UNKNOWN},
+	{15, 0,   0, "Jungletac", MIRRORING_UNKNOWN},
 };
 
 // Mapper 268: SMD132/SMD133
 const struct NESMappersPrivate::SubmapperInfo NESMappersPrivate::smd132_smd133_submappers[] = {
-	{0, 0,   0, "COOLBOY ($6000-$7FFF)"},
-	{1, 0,   0, "MINDKIDS ($5000-$5FFF)"},
+	{0, 0,   0, "COOLBOY ($6000-$7FFF)", MIRRORING_UNKNOWN},
+	{1, 0,   0, "MINDKIDS ($5000-$5FFF)", MIRRORING_UNKNOWN},
 };
 
 // Mapper 313: Reset-based multicart (MMC3)
 const struct NESMappersPrivate::SubmapperInfo NESMappersPrivate::mapper313_submappers[] = {
-	{0, 0,   0, "Game size: 128 KiB PRG, 128 KiB CHR"},
-	{1, 0,   0, "Game size: 256 KiB PRG, 128 KiB CHR"},
-	{2, 0,   0, "Game size: 128 KiB PRG, 256 KiB CHR"},
-	{3, 0,   0, "Game size: 256 KiB PRG, 256 KiB CHR"},
-	{4, 0,   0, "Game size: 256 KiB PRG (first game); 128 KiB PRG (other games); 128 KiB CHR"},
+	{0, 0,   0, "Game size: 128 KiB PRG, 128 KiB CHR", MIRRORING_UNKNOWN},
+	{1, 0,   0, "Game size: 256 KiB PRG, 128 KiB CHR", MIRRORING_UNKNOWN},
+	{2, 0,   0, "Game size: 128 KiB PRG, 256 KiB CHR", MIRRORING_UNKNOWN},
+	{3, 0,   0, "Game size: 256 KiB PRG, 256 KiB CHR", MIRRORING_UNKNOWN},
+	{4, 0,   0, "Game size: 256 KiB PRG (first game); 128 KiB PRG (other games); 128 KiB CHR", MIRRORING_UNKNOWN},
 };
 
 /**
@@ -888,14 +942,12 @@ int RP_C_API NESMappersPrivate::SubmapperEntry_compar(const void *a, const void 
 	return 0;
 }
 
-/** NESMappers **/
-
 /**
  * Look up an iNES mapper number.
  * @param mapper Mapper number.
- * @return Mapper name, or nullptr if not found.
+ * @return Mapper info, or nullptr if not found.
  */
-const char *NESMappers::lookup_ines(int mapper)
+const NESMappersPrivate::MapperEntry *NESMappersPrivate::lookup_ines_info(int mapper)
 {
 	assert(mapper >= 0);
 	if (mapper < 0) {
@@ -905,29 +957,79 @@ const char *NESMappers::lookup_ines(int mapper)
 
 	if (mapper < 256) {
 		// NES 2.0 Plane 0 [000-255] (iNES 1.0)
-		static_assert(sizeof(NESMappersPrivate::mappers_plane0) == (256 * sizeof(NESMappersPrivate::MapperEntry)),
+		static_assert(sizeof(mappers_plane0) == (256 * sizeof(MapperEntry)),
 			"NESMappersPrivate::mappers_plane0[] doesn't have 256 entries.");
-		return NESMappersPrivate::mappers_plane0[mapper].name;
+		return &mappers_plane0[mapper];
 	} else if (mapper < 512) {
 		// NES 2.0 Plane 1 [256-511]
 		mapper -= 256;
-		if (mapper >= ARRAY_SIZE_I(NESMappersPrivate::mappers_plane1)) {
+		if (mapper >= ARRAY_SIZE_I(mappers_plane1)) {
 			// Mapper number is out of range for plane 1.
 			return nullptr;
 		}
-		return NESMappersPrivate::mappers_plane1[mapper].name;
+		return &mappers_plane1[mapper];
 	} else if (mapper < 768) {
 		// NES 2.0 Plane 2 [512-767]
 		mapper -= 512;
-		if (mapper >= ARRAY_SIZE_I(NESMappersPrivate::mappers_plane2)) {
+		if (mapper >= ARRAY_SIZE_I(mappers_plane2)) {
 			// Mapper number is out of range for plane 2.
 			return nullptr;
 		}
-		return NESMappersPrivate::mappers_plane2[mapper].name;
+		return &mappers_plane2[mapper];
 	}
 
 	// Invalid mapper number.
 	return nullptr;
+}
+
+/**
+ * Look up an NES 2.0 submapper number.
+ * @param mapper Mapper number.
+ * @param submapper Submapper number.
+ * @return Submapper info, or nullptr if not found.
+ */
+const NESMappersPrivate::SubmapperInfo *NESMappersPrivate::lookup_nes2_submapper_info(int mapper, int submapper)
+{
+	assert(mapper >= 0);
+	assert(submapper >= 0);
+	assert(submapper < 256);
+	if (mapper < 0 || submapper < 0 || submapper >= 256) {
+		// Mapper or submapper number is out of range.
+		return nullptr;
+	}
+
+	// Do a binary search in submappers[].
+	const SubmapperEntry key = { static_cast<uint16_t>(mapper), 0, nullptr };
+	const SubmapperEntry *res =
+		static_cast<const SubmapperEntry*>(bsearch(&key,
+			submappers,
+			ARRAY_SIZE(submappers)-1,
+			sizeof(SubmapperEntry),
+			SubmapperEntry_compar));
+	if (!res || !res->info || res->info_size == 0)
+		return nullptr;
+
+	// Do a binary search in res->info.
+	const SubmapperInfo key2 = { static_cast<uint8_t>(submapper), 0, 0, nullptr, MIRRORING_UNKNOWN };
+	const SubmapperInfo *res2 =
+		static_cast<const SubmapperInfo*>(bsearch(&key2,
+			res->info, res->info_size,
+			sizeof(SubmapperInfo),
+			SubmapperInfo_compar));
+	return res2;
+}
+
+/** NESMappers **/
+
+/**
+ * Look up an iNES mapper number.
+ * @param mapper Mapper number.
+ * @return Mapper name, or nullptr if not found.
+ */
+const char *NESMappers::lookup_ines(int mapper)
+{
+	const NESMappersPrivate::MapperEntry *ent = NESMappersPrivate::lookup_ines_info(mapper);
+	return ent ? ent->name : nullptr;
 }
 
 /**
@@ -1024,34 +1126,93 @@ int NESMappers::tnesMapperToInesMapper(int tnes_mapper)
  */
 const char *NESMappers::lookup_nes2_submapper(int mapper, int submapper)
 {
-	assert(mapper >= 0);
-	assert(submapper >= 0);
-	assert(submapper < 256);
-	if (mapper < 0 || submapper < 0 || submapper >= 256) {
-		// Mapper or submapper number is out of range.
-		return nullptr;
+	const NESMappersPrivate::SubmapperInfo *ent = NESMappersPrivate::lookup_nes2_submapper_info(mapper, submapper);
+	// TODO: Return the "deprecated" value?
+	return ent ? ent->desc : nullptr;
+}
+
+/**
+ * Look up a description of mapper mirroring behavior
+ * @param mapper Mapper number.
+ * @param submapper Submapper number.
+ * @param vert Vertical bit in the iNES header
+ * @param vert Four-screen bit in the iNES header
+ * @return String describing the mirroring behavior
+ */
+const char *NESMappers::lookup_ines_mirroring(int mapper, int submapper, bool vert, bool four)
+{
+	const NESMappersPrivate::MapperEntry *ent1 = NESMappersPrivate::lookup_ines_info(mapper);
+	const NESMappersPrivate::SubmapperInfo *ent2 = NESMappersPrivate::lookup_nes2_submapper_info(mapper, submapper);
+	int mirror = ent1 ? ent1->mirroring : MIRRORING_UNKNOWN;
+	int submapper_mirror = ent2 ? ent2->mirroring :MIRRORING_UNKNOWN;
+
+	if (submapper_mirror != MIRRORING_UNKNOWN) // Override mapper's value
+		mirror = submapper_mirror;
+
+	// Handle some special cases
+	switch (mirror) {
+		case MIRRORING_UNKNOWN:
+			// Default to showing the header flags
+			mirror = four ? MIRRORING_4SCREEN : MIRRORING_HEADER;
+			break;
+		case MIRRORING_UNROM512:
+			// xxxx0xx0 - Horizontal mirroring
+			// xxxx0xx1 - Vertical mirroring
+			// xxxx1xx0 - Mapper-controlled, single screen
+			// xxxx1xx1 - Four screens
+			mirror = four ? (vert ? MIRRORING_4SCREEN : MIRRORING_MAPPER_AB) : MIRRORING_HEADER;
+			break;
+		case MIRRORING_BANDAI_FAMILYTRAINER:
+			// Mapper 152 should be used instead of setting 4sc on this mapper (70).
+			mirror = four ? MIRRORING_MAPPER_AB : MIRRORING_HEADER;
+			break;
+		case MIRRORING_MAGICFLOOR:
+			// Magic Floor maps CIRAM across the entire PPU address space
+			// CIRAM A10:   A10  A11  A12  A13
+			// iNES flag6: 0xx1 0xx0 1xx0 1xx1
+			//       $0000   aB   aa   aa   aa < pattern table 1
+			//       $0800   aB   BB   aa   aa
+			//       $1000   aB   aa   BB   aa < pattern table 2
+			//       $1800   aB   BB   BB   aa
+			//       $2000   aB   aa   aa   BB < nametables
+			//       $2800   aB   BB   aa   BB
+			//       $3000   aB   aa   BB   BB < unused memory
+			//       $3800   aB   BB   BB   BB
+			// Mirroring:  Vert Hori 1scA 1scB
+			//
+			// It's important to differentiate between 1scA and 1scB as it affects
+			// pattern table mapping.
+			mirror = four ? (vert ? MIRRORING_1SCREEN_B : MIRRORING_1SCREEN_A)
+				      : MIRRORING_HEADER;
+			break;
+		default:
+			// In other modes, four screens overrides everything else
+			if (four)
+				mirror = MIRRORING_4SCREEN;
+			break;
 	}
 
-	// Do a binary search in submappers[].
-	const NESMappersPrivate::SubmapperEntry key = { static_cast<uint16_t>(mapper), 0, nullptr };
-	const NESMappersPrivate::SubmapperEntry *res =
-		static_cast<const NESMappersPrivate::SubmapperEntry*>(bsearch(&key,
-			NESMappersPrivate::submappers,
-			ARRAY_SIZE(NESMappersPrivate::submappers)-1,
-			sizeof(NESMappersPrivate::SubmapperEntry),
-			NESMappersPrivate::SubmapperEntry_compar));
-	if (!res || !res->info || res->info_size == 0)
-		return nullptr;
-
-	// Do a binary search in res->info.
-	const NESMappersPrivate::SubmapperInfo key2 = { static_cast<uint8_t>(submapper), 0, 0, nullptr };
-	const NESMappersPrivate::SubmapperInfo *res2 =
-		static_cast<const NESMappersPrivate::SubmapperInfo*>(bsearch(&key2,
-			res->info, res->info_size,
-			sizeof(NESMappersPrivate::SubmapperInfo),
-			NESMappersPrivate::SubmapperInfo_compar));
-	// TODO: Return the "deprecated" value?
-	return (res2 ? res2->desc : nullptr);
+	// NOTE: to prevent useless noise like "Mapper: MMC5, Mirroring: MMC5-like", all of the weird
+	// mirroring types are grouped under "Mapper-controlled"
+	switch (mirror) {
+		case MIRRORING_HEADER:
+			return vert ? C_("NES|Mirroring", "Vertical") : C_("NES|Mirroring", "Horizontal");
+		case MIRRORING_MAPPER:
+		default:
+			return C_("NES|Mirroring", "Mapper-controlled");
+		case MIRRORING_MAPPER_HVAB:
+			return C_("NES|Mirroring", "Mapper-controlled (H/V/A/B)");
+		case MIRRORING_MAPPER_HV:
+			return C_("NES|Mirroring", "Mapper-controlled (H/V)");
+		case MIRRORING_MAPPER_AB:
+			return C_("NES|Mirroring", "Mapper-controlled (A/B)");
+		case MIRRORING_1SCREEN_A:
+			return C_("NES|Mirroring", "Single Screen (A)");
+		case MIRRORING_1SCREEN_B:
+			return C_("NES|Mirroring", "Single Screen (B)");
+		case MIRRORING_4SCREEN:
+			return C_("NES|Mirroring", "Four Screens");
+	}
 }
 
 }

--- a/src/libromdata/data/NESMappers.hpp
+++ b/src/libromdata/data/NESMappers.hpp
@@ -3,7 +3,7 @@
  * NESMappers.hpp: NES mapper data.                                        *
  *                                                                         *
  * Copyright (c) 2016-2020 by David Korth.                                 *
- * Copyright (c) 2016-2018 by Egor.                                        *
+ * Copyright (c) 2016-2022 by Egor.                                        *
  * SPDX-License-Identifier: GPL-2.0-or-later                               *
  ***************************************************************************/
  
@@ -45,6 +45,16 @@ class NESMappers
 		 * @return Submapper name, or nullptr if not found.
 		 */
 		static const char *lookup_nes2_submapper(int mapper, int submapper);
+
+		/**
+		 * Look up a description of mapper mirroring behavior
+		 * @param mapper Mapper number.
+		 * @param submapper Submapper number.
+		 * @param vert Vertical bit in the iNES header
+		 * @param vert Four-screen bit in the iNES header
+		 * @return String describing the mirroring behavior
+		 */
+		static const char *lookup_ines_mirroring(int mapper, int submapper, bool vert, bool four);
 };
 
 }


### PR DESCRIPTION
originally done on March 22-24 2020 (happens to be exactly two years ago)

The enum contains much more info than it makes sense to output. In particular the distinction between 150/244 and 233 is a bit subtle.

Attached is result of running `rpcli * 2>&1 | grep '^== Reading file\|^Mirroring: '` on GoodNES V3.23b. (Duplicate lines are due to internal headers)
[testout.txt](https://github.com/GerbilSoft/rom-properties/files/8342312/testout.txt)