### PR TITLE
EXE PE: Exports/Imports tabs

### DIFF
--- a/src/libromdata/Other/EXE_p.hpp
+++ b/src/libromdata/Other/EXE_p.hpp
@@ -185,6 +185,27 @@ class EXEPrivate final : public LibRpBase::RomDataPrivate
 		int readPEImpExpDir(IMAGE_DATA_DIRECTORY &dataDir, int type,
 			size_t minSize, size_t maxSize, ao::uvector<uint8_t> &dirTbl);
 
+		/**
+		 * Read a block of null-terminated strings, where the length of the
+		 * last one isn't known in advance.
+		 *
+		 * The amount that will be read is:
+		 * (high - low) + minExtra + maxExtra
+		 * Which must be in the range [minMax; minMax + maxExtra]
+		 *
+		 * @param low RVA of first string.
+		 * @param high RVA of last string.
+		 * @param minExtra Last string must be at least this long.
+		 * @param minMax The minimum size of the block must be smaller than this.
+		 * @param maxExtra How many extra bytes can be read.
+		 * @param outPtr Resulting array.
+		 * @param outSize How much data was read.
+		 * @return 0 on success; negative POSIX error code on error.
+		 */
+		int readPENullBlock(uint32_t low, uint32_t high, uint32_t minExtra,
+			uint32_t minMax, uint32_t maxExtra, std::unique_ptr<char[]> &outPtr,
+			size_t &outSize);
+
 		// PE Import Directory
 		std::vector<IMAGE_IMPORT_DIRECTORY> peImportDir;
 		// PE Import DLL Names (same order as the directory)
@@ -251,6 +272,12 @@ class EXEPrivate final : public LibRpBase::RomDataPrivate
 		 * @return 0 on success; negative POSIX error code on error.
 		 */
 		int addFields_PE_Export(void);
+
+		/**
+		 * Add fields for PE import table.
+		 * @return 0 on success; negative POSIX error code on error.
+		 */
+		int addFields_PE_Import(void);
 };
 
 }

--- a/src/libromdata/Other/EXE_p.hpp
+++ b/src/libromdata/Other/EXE_p.hpp
@@ -185,6 +185,19 @@ class EXEPrivate final : public LibRpBase::RomDataPrivate
 		int readPEImpExpDir(IMAGE_DATA_DIRECTORY &dataDir, int type,
 			size_t minSize, size_t maxSize, ao::uvector<uint8_t> &dirTbl);
 
+		// PE Import Directory
+		std::vector<IMAGE_IMPORT_DIRECTORY> peImportDir;
+		// PE Import DLL Names (same order as the directory)
+		std::vector<std::string> peImportNames;
+		// Whether peImportDir and peImportNames were already loaded.
+		bool peImportDirLoaded = false;
+
+		/**
+		 * Read PE Import Directory (peImportDir) and DLL names (peImportNames).
+		 * @return 0 on success; negative POSIX error code on error.
+		 */
+		int readPEImportDir(void);
+
 	public:
 		/**
 		 * Find the runtime DLL. (PE version)

--- a/src/libromdata/Other/EXE_p.hpp
+++ b/src/libromdata/Other/EXE_p.hpp
@@ -172,6 +172,20 @@ class EXEPrivate final : public LibRpBase::RomDataPrivate
 		 */
 		int loadPEResourceTypes(void);
 
+	private:
+		/**
+		 * Read PE import/export directory
+		 * @param dataDir RVA/Size of directory will be stored here.
+		 * @param type One of IMAGE_DATA_DIRECTORY_{EXPORT,IMPORT}_TABLE
+		 * @param minSize Minimum direcrory size
+		 * @param maxSize Maximum directory size
+		 * @param dirTbl Vector into which the directory will be read.
+		 * @return 0 on success; negative POSIX error code on error.
+		 */
+		int readPEImpExpDir(IMAGE_DATA_DIRECTORY &dataDir, int type,
+			size_t minSize, size_t maxSize, ao::uvector<uint8_t> &dirTbl);
+
+	public:
 		/**
 		 * Find the runtime DLL. (PE version)
 		 * @param refDesc String to store the description.

--- a/src/libromdata/Other/EXE_p.hpp
+++ b/src/libromdata/Other/EXE_p.hpp
@@ -217,6 +217,13 @@ class EXEPrivate final : public LibRpBase::RomDataPrivate
 		 */
 		bool doesExeRequireAdministrator(void) const;
 #endif /* ENABLE_XML */
+
+	public:
+		/**
+		 * Add fields for PE export table.
+		 * @return 0 on success; negative POSIX error code on error.
+		 */
+		int addFields_PE_Export(void);
 };
 
 }

--- a/src/libromdata/Other/exe_structs.h
+++ b/src/libromdata/Other/exe_structs.h
@@ -335,6 +335,25 @@ typedef struct _IMAGE_SECTION_HEADER {
 } IMAGE_SECTION_HEADER;
 ASSERT_STRUCT(IMAGE_SECTION_HEADER, IMAGE_SIZEOF_SECTION_HEADER);
 
+/**
+ * Export directory.
+ * Reference: https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#export-directory-table
+ */
+typedef struct _IMAGE_EXPORT_DIRECTORY {
+	uint32_t Characteristics;	// Reserved
+	uint32_t TimeDateStamp;		// UNIX timestamp
+	uint16_t MajorVersion;
+	uint16_t MinorVersion;
+	uint32_t Name;			// DLL name
+	uint32_t Base;			// The starting ordinal number
+	uint32_t NumberOfFunctions;	// Size of address table
+	uint32_t NumberOfNames;		// Size of name table
+	uint32_t AddressOfFunctions;	// RVA of address table
+	uint32_t AddressOfNames;	// RVA of name table
+	uint32_t AddressOfNameOrdinals;	// RVA of name-to-ordinal table
+} IMAGE_EXPORT_DIRECTORY;
+ASSERT_STRUCT(IMAGE_EXPORT_DIRECTORY, 10*sizeof(uint32_t));
+
 /** Import table. **/
 // Reference: http://sandsprite.com/CodeStuff/Understanding_imports.html
 


### PR DESCRIPTION
fixes #348

I apologize in advance for addFields_PE_Import being particularly ugly.

Further areas of improvements:
- Delay-loaded imports
- Name demangling
- Imports/exports for other formats
  - NE
  - ELF
- The name field should be limited in width, because otherwise symbols like `?getFromListDataMulti@RomFields@LibRpBase@@SAPBV?$vector@V?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@V?$allocator@V?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@@2@@std@@PBV?$map@IV?$vector@V?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@V?$allocator@V?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@@2@@std@@U?$less@I@2@V?$allocator@U?$pair@$$CBIV?$vector@V?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@V?$allocator@V?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@@2@@std@@@std@@@2@@4@II@Z` stretch it very far
- UI stuff I mentioned in #348 maybe?