### PR TITLE
zlib-ng: Check that the OS supports saving the YMM registers before enabling AVX2

### DIFF
--- a/extlib/zlib-ng/_MODIFIED_ZLIB.txt
+++ b/extlib/zlib-ng/_MODIFIED_ZLIB.txt
@@ -18,6 +18,8 @@ Tag: 2.0.6
 
 The following changes have been made to the original:
 
+- Now checks that the OS supports saving the YMM registers before enabling AVX2.
+
 - CMakeLists.txt has been edited to prevent building the Win32 resource
   data when being built as a shared library.
 

--- a/extlib/zlib-ng/arch/x86/x86.h
+++ b/extlib/zlib-ng/arch/x86/x86.h
@@ -12,6 +12,7 @@ extern int x86_cpu_has_ssse3;
 extern int x86_cpu_has_sse42;
 extern int x86_cpu_has_pclmulqdq;
 extern int x86_cpu_has_tzcnt;
+extern int x86_cpu_has_os_save_ymm;
 
 void Z_INTERNAL x86_check_features(void);
 


### PR DESCRIPTION
Fixes #361.