### PR TITLE
[kde] register RpQImageBackend when RomThumbCreator is used

### DIFF
--- a/src/kde/RomThumbCreator.cpp
+++ b/src/kde/RomThumbCreator.cpp
@@ -12,6 +12,7 @@
 
 #include "RomThumbCreator.hpp"
 #include "RpQImageBackend.hpp"
+#include "AchQtDBus.hpp"
 #include "ProxyForUrl.hpp"
 
 // librpbase, librptexture
@@ -49,6 +50,12 @@ using std::unique_ptr;
 extern "C" {
 	Q_DECL_EXPORT ThumbCreator *new_creator()
 	{
+		// Register RpQImageBackend and AchQtDBus.
+		rp_image::setBackendCreatorFn(RpQImageBackend::creator_fn);
+#if defined(ENABLE_ACHIEVEMENTS) && defined(HAVE_QtDBus_NOTIFY)
+		AchQtDBus::instance();
+#endif /* ENABLE_ACHIEVEMENTS && HAVE_QtDBus_NOTIFY */
+
 		return new RomThumbCreator();
 	}
 }


### PR DESCRIPTION
fixes #372