### PR TITLE
[libromdata] Lua: Add support for Lua 5.5 bytecode format.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## v2.8 (released 2026/??/??)
 
+* New parser features:
+  * Lua: Support for Lua 5.5 bytecode format.
+
 ## v2.7.1 (released 2026/01/18)
 
 * New features:

--- a/src/libromdata/Other/lua_structs.h
+++ b/src/libromdata/Other/lua_structs.h
@@ -30,10 +30,11 @@ extern "C" {
  * 5.0: 14+Number
  * 5.1: 12
  * 5.2: 18
- * 5.3: 17+Integer+Number (the biggest one)
+ * 5.3: 17+Integer+Number
  * 5.4: 15+Integer+Number
+ * 5.5: 16+int+Instruction+Integer+Number (the biggest one)
  */
-#define LUA_HEADERSIZE (17+8+8)
+#define LUA_HEADERSIZE (16+8+8+8+8)
 
 /**
  * Lua binary chunk header.
@@ -188,6 +189,25 @@ typedef struct _Lua5_4_Header {
 	/* followed by test number 370.5 */
 } Lua5_4_Header;
 ASSERT_STRUCT(Lua5_4_Header, 15);
+
+/**
+ * Lua 5.5 binary chunk header.
+ */
+typedef struct _Lua5_5_Header {
+	Lua_Header header;
+	uint8_t format; /* 0 = official format */
+	char tail[6]; /* LUA_TAIL */
+	/* uint8_t int_size;
+	 * followed by test int -0x5678
+	 * uint8_t Instruction_size;
+	 * followed by test instruction 0x12345678
+	 * uint8_t Integer_size;
+	 * followed by test integer -0x5678
+	 * uint8_t Number_size;
+	 * followed by test number -370.5
+	 */
+} Lua5_5_Header;
+ASSERT_STRUCT(Lua5_5_Header, 12);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
```
xxd -r >5.5.lub <<EOF
00000000: 1b4c 7561 5500 1993 0d0a 1a0a 0488 a9ff  .LuaU...........
00000010: ff04 7856 3412 0888 a9ff ffff ffff ff08  ..xV4...........
00000020: 0000 0000 0028 77c0 0100 0000 0102 0500  .....(w.........
00000030: 5300 0000 0b00 0000 8380 0000 4400 0201  S...........D...
00000040: 4600 0101 0204 0670 7269 6e74 0004 0e48  F......print...H
00000050: 656c 6c6f 2c20 576f 726c 6421 0001 0100  ello, World!....
00000060: 0000 0b40 696e 7075 742e 6c75 6100 0501  ...@input.lua...
00000070: 0000 0000 0000 0105 5f45 4e56 00         ........_ENV.
EOF
```
```
== Reading file '5.5.lub'...
-- PUC Lua 5.5 Executable detected
Endianness:           'Little-Endian'
int size:             '4'
lua_Instruction size: '4'
lua_Integer size:     '8'
lua_Number size:      '8'
lua_Number type:      'Floating-point'
```