### PR TITLE
[librpfile] Fix missing fcntl.h include

### DIFF
--- a/src/librpfile/RpFile_stdio.cpp
+++ b/src/librpfile/RpFile_stdio.cpp
@@ -22,6 +22,7 @@
 #include "librpbyteswap/byteswap_rp.h"
 
 // C includes
+#include <fcntl.h>	// fcntl(), F_GETFD, F_SETFD
 #include <unistd.h>	// ftruncate()
 
 // C++ STL classes


### PR DESCRIPTION
This fixes compilation on Mac OS X.