### PR TITLE
[xdg] mime.no-thumbnail.types: Add application/x-ms-dll

### DIFF
--- a/xdg/mime.no-thumbnail.types
+++ b/xdg/mime.no-thumbnail.types
@@ -77,6 +77,7 @@ application/x-dosexec			# EXE
 application/x-ms-dos-executable		# EXE
 application/x-ms-ne-executable		# EXE
 application/x-msdownload		# EXE
+application/x-ms-dll			# DLL
 text/vnd.sun.j2me.app-descriptor	# J2ME
 application/x-mach-object		# MachO
 application/x-mach-executable		# MachO


### PR DESCRIPTION
Fixes DLLs not having the ROM Properties tab on KDE Plasma 6 with Dolphin.