### PR TITLE
PlayStation PARAM.SFO reader

### DIFF
--- a/src/libromdata/CMakeLists.txt
+++ b/src/libromdata/CMakeLists.txt
@@ -81,6 +81,8 @@ SET(${PROJECT_NAME}_SRCS
 	Handheld/WonderSwan.cpp
 	Handheld/nds_crc.cpp
 
+	Common/ParamSFO.cpp
+
 	Audio/ADX.cpp
 	Audio/BCSTM.cpp
 	Audio/BRSTM.cpp

--- a/src/libromdata/Common/ParamSFO.cpp
+++ b/src/libromdata/Common/ParamSFO.cpp
@@ -222,7 +222,7 @@ ParamSFO::SFOValueType ParamSFO::getKeyValueType(std::string key)
 {
 	RP_D(ParamSFO);
 
-	if (!d->keyLookup.contains(key)) {
+	if (d->keyLookup.find(key) == d->keyLookup.end()) {
 		return SFOValueType::None;
 	}
 
@@ -242,7 +242,7 @@ const std::string ParamSFO::getStringValue(std::string key)
 	// TODO: Can we error out of this function?
 
 	RP_D(ParamSFO);
-	if (d->cachedStringValues.contains(key)) {
+	if (d->cachedStringValues.find(key) != d->cachedStringValues.end()) {
 		// We already fetched a string value for that key.
 		return d->cachedStringValues[key];
 	} else if (!d->file) {
@@ -251,7 +251,7 @@ const std::string ParamSFO::getStringValue(std::string key)
 	} else if (!d->isValid) {
 		// File isn't valid
 		return string();
-	} else if (!d->keyLookup.contains(key)) {
+	} else if (d->keyLookup.find(key) == d->keyLookup.end()) {
 		// We don't have this key
 		return string();
 	}
@@ -279,7 +279,7 @@ uint32_t ParamSFO::getIntValue(std::string key)
 {
 	// TODO: Can we error out of this function?
 	RP_D(ParamSFO);
-	if (d->cachedIntValues.contains(key)) {
+	if (d->cachedIntValues.find(key) != d->cachedIntValues.end()) {
 		// We already fetched a string value for that key.
 		return d->cachedIntValues[key];
 	} else if (!d->file) {
@@ -288,7 +288,7 @@ uint32_t ParamSFO::getIntValue(std::string key)
 	} else if (!d->isValid) {
 		// File isn't valid
 		return 0;
-	} else if (!d->keyLookup.contains(key)) {
+	} else if (d->keyLookup.find(key) == d->keyLookup.end()) {
 		// We don't have this key
 		return 0;
 	}

--- a/src/libromdata/Common/ParamSFO.cpp
+++ b/src/libromdata/Common/ParamSFO.cpp
@@ -50,7 +50,7 @@ public:
 	psf_header_t fileHeader;
 
 	// PSF key data.
-	rp::uvector<psf_key_t> keys;
+	vector<psf_key_t> keys;
 	unordered_map<std::string, psf_key_t> keyLookup;
 
 	// Key/value lookup cache.

--- a/src/libromdata/Common/ParamSFO.cpp
+++ b/src/libromdata/Common/ParamSFO.cpp
@@ -1,0 +1,399 @@
+/***************************************************************************
+ * ROM Properties Page shell extension. (libromdata)                       *
+ * ParamSFO.cpp: PlayStation PARAM.SFO / PSF reader                        *
+ *                                                                         *
+ * Copyright (c) 2016-2026 by David Korth.                                 *
+ * Copyright (c) 2026 by Emma / InvoxiPlayGames.                           *
+ * SPDX-License-Identifier: GPL-2.0-or-later                               *
+ ***************************************************************************/
+
+#include "ParamSFO.hpp"
+#include "RomData_p.hpp"
+
+#include "paramsfo_structs.h"
+
+#include <cstdint>
+
+// Other rom-properties libraries
+using namespace LibRpBase;
+using namespace LibRpFile;
+using namespace LibRpText;
+
+// C++ STL classes
+using std::array;
+using std::string;
+using std::vector;
+#include <unordered_map>
+using std::unordered_map;
+
+namespace LibRomData {
+
+class ParamSFOPrivate final : public RomDataPrivate
+{
+public:
+	explicit ParamSFOPrivate(const IRpFilePtr &file);
+
+private:
+	typedef RomDataPrivate super;
+	RP_DISABLE_COPY(ParamSFOPrivate);
+
+	int readNullTerminatedString(uint32_t offset, std::string &str);
+	int readString(uint32_t offset, size_t length, std::string &str);
+
+public:
+	/** RomDataInfo **/
+	static const array<const char *, 1 + 1> exts;
+	static const array<const char *, 1 + 1> mimeTypes;
+	static const RomDataInfo romDataInfo;
+
+	// PSF header.
+	psf_header_t fileHeader;
+
+	// PSF key data.
+	rp::uvector<psf_key_t> keys;
+	unordered_map<std::string, psf_key_t> keyLookup;
+
+	// Key/value lookup cache.
+	unordered_map<std::string, std::string> cachedStringValues;
+	unordered_map<std::string, uint32_t> cachedIntValues;
+
+	bool isBigEndian;
+};
+
+ROMDATA_IMPL(ParamSFO)
+
+const array<const char *, 1 + 1> ParamSFOPrivate::exts = {{".sfo", nullptr}};
+
+const array<const char *, 1 + 1> ParamSFOPrivate::mimeTypes = {{// Unofficial MIME type.
+	// TODO: Get this upstreamed on FreeDesktop.org.
+	"application/x-playstation-sfo", nullptr}};
+
+const RomDataInfo ParamSFOPrivate::romDataInfo = {"PARAM.SFO", exts.data(), mimeTypes.data()};
+
+int ParamSFOPrivate::readNullTerminatedString(uint32_t offset, std::string &str)
+{
+	if (offset == 0)
+		return 0;
+
+	if (file->seek(offset) != 0)
+		return -1; // failed to seek
+	// really bad, loop a read of a single byte til we reach a NULL
+	char c = 0;
+	do {
+		if (file->read(&c, sizeof(c)) != sizeof(c))
+			return -2; // failed to read
+		if (c != 0)
+			str.push_back(c);
+	} while (c != 0);
+	return 1;
+}
+
+int ParamSFOPrivate::readString(uint32_t offset, size_t length, std::string &str)
+{
+	if (offset == 0)
+		return 0;
+
+	// resize the string buffer
+	str.resize(length);
+
+	if (file->seekAndRead(offset, str.data(), length) != length)
+		return -1; // failed
+
+	return 1;
+}
+
+ParamSFOPrivate::ParamSFOPrivate(const IRpFilePtr &file)
+	: super(file, &romDataInfo)
+{
+	memset(&fileHeader, 0, sizeof(fileHeader));
+	isBigEndian = false;
+}
+
+int ParamSFO::isRomSupported_static(const DetectInfo *info)
+{
+	assert(info != nullptr);
+	assert(info->header.pData != nullptr);
+	assert(info->header.addr == 0);
+	if (!info || !info->header.pData || info->header.addr != 0 || info->header.size < sizeof(psf_header_t)) {
+		return -1;
+	}
+
+	const psf_header_t *const psfheader = reinterpret_cast<const psf_header_t *>(info->header.pData);
+
+	if (psfheader->magic != be32_to_cpu(PSF_MAGIC) || psfheader->version != be32_to_cpu(PSF_VERSION)) {
+		return -1;
+	}
+
+	return 0;
+}
+
+ParamSFO::ParamSFO(const IRpFilePtr &file)
+	: super(new ParamSFOPrivate(file))
+{
+	RP_D(ParamSFO);
+
+	if (!d->file) {
+		// Could not ref() the file handle.
+		return;
+	}
+
+	// Read the PSF header.
+	uint8_t header_bytes[sizeof(psf_header_t)];
+	d->file->rewind();
+	size_t size = d->file->read(header_bytes, sizeof(psf_header_t));
+	if (size != sizeof(psf_header_t)) {
+		d->isValid = false;
+		d->file.reset();
+		return;
+	}
+
+	// Check if this file is supported.
+	const DetectInfo info = {{0, sizeof(psf_header_t), header_bytes}, nullptr, 0};
+	if (isRomSupported_static(&info) < 0) {
+		d->isValid = false;
+		d->file.reset();
+		return;
+	}
+
+	// Copy the header into our class.
+	memcpy(&d->fileHeader, header_bytes, sizeof(psf_header_t));
+
+#if SYS_BYTEORDER == SYS_BIG_ENDIAN
+	// Byteswap the header.
+	d->fileHeader.magic = le32_to_cpu(d->fileHeader.magic);
+	d->fileHeader.version = le32_to_cpu(d->fileHeader.version);
+	d->fileHeader.keyOffset = le32_to_cpu(d->fileHeader.keyOffset);
+	d->fileHeader.dataOffset = le32_to_cpu(d->fileHeader.dataOffset);
+	d->fileHeader.numKeys = le32_to_cpu(d->fileHeader.numKeys);
+#endif
+
+	// Read the key table.
+	d->keys.resize(d->fileHeader.numKeys);
+	for (int i = 0; i < d->fileHeader.numKeys; i++) {
+		psf_key_t key;
+		size = d->file->read(&key, sizeof(psf_key_t));
+		if (size != sizeof(psf_key_t)) {
+			d->isValid = false;
+			d->file.reset();
+			return;
+		}
+
+#if SYS_BYTEORDER == SYS_BIG_ENDIAN
+		// Byteswap the key.
+		key.keyNameOffset = le16_to_cpu(key.keyNameOffset);
+		key.valueType = le16_to_cpu(key.valueType);
+		key.dataLength = le32_to_cpu(key.dataLength);
+		key.dataMax = le32_to_cpu(key.dataMax);
+		key.dataOffset = le32_to_cpu(key.dataOffset);
+#endif
+
+		// Ensure it's a data format we know.
+		assert(key.valueType == kPSF_Int32 || key.valueType == kPSF_UTF8);
+		if (key.valueType != kPSF_Int32 && key.valueType != kPSF_UTF8) {
+			d->isValid = false;
+			d->file.reset();
+			return;
+		}
+
+		d->keys[i] = key;
+	}
+
+	// Read the key names.
+	d->keyLookup.reserve(d->keys.size());
+	for (psf_key_t key : d->keys) {
+		// Read the name of the key.
+		std::string keyName;
+		if (!d->readNullTerminatedString(d->fileHeader.keyOffset + key.keyNameOffset, keyName)) {
+			d->isValid = false;
+			d->file.reset();
+			return;
+		}
+
+		d->keyLookup[keyName] = key;
+	}
+
+	d->isValid = true;
+
+	d->fileType = FileType::ConfigurationFile;
+	d->mimeType = "application/x-playstation-sfo";
+}
+
+ParamSFO::SFOValueType ParamSFO::getKeyValueType(std::string key)
+{
+	RP_D(ParamSFO);
+
+	if (!d->keyLookup.contains(key)) {
+		return SFOValueType::None;
+	}
+
+	psf_key_t *psfKey = &d->keyLookup[key];
+
+	if (psfKey->valueType == kPSF_UTF8) {
+		return SFOValueType::UTF8;
+	} else if (psfKey->valueType == kPSF_Int32) {
+		return SFOValueType::Int32;
+	} else {
+		return SFOValueType::None;
+	}
+}
+
+const std::string ParamSFO::getStringValue(std::string key)
+{
+	// TODO: Can we error out of this function?
+
+	RP_D(ParamSFO);
+	if (d->cachedStringValues.contains(key)) {
+		// We already fetched a string value for that key.
+		return d->cachedStringValues[key];
+	} else if (!d->file) {
+		// File isn't open.
+		return string();
+	} else if (!d->isValid) {
+		// File isn't valid
+		return string();
+	} else if (!d->keyLookup.contains(key)) {
+		// We don't have this key
+		return string();
+	}
+
+	psf_key_t *psfKey = &d->keyLookup[key];
+	if (psfKey->valueType != kPSF_UTF8) {
+		// Not a UTF8 key.
+		return string();
+	}
+
+	std::string value;
+	// HACK: We take 1 off the data length to trim null terminators.
+	if (!d->readString(d->fileHeader.dataOffset + psfKey->dataOffset, psfKey->dataLength - 1, value)) {
+		// Failed to read the value.
+		return string();
+	}
+
+	// Cache the value for later.
+	d->cachedStringValues[key] = value;
+
+	return value;
+}
+
+uint32_t ParamSFO::getIntValue(std::string key)
+{
+	// TODO: Can we error out of this function?
+	RP_D(ParamSFO);
+	if (d->cachedIntValues.contains(key)) {
+		// We already fetched a string value for that key.
+		return d->cachedIntValues[key];
+	} else if (!d->file) {
+		// File isn't open.
+		return 0;
+	} else if (!d->isValid) {
+		// File isn't valid
+		return 0;
+	} else if (!d->keyLookup.contains(key)) {
+		// We don't have this key
+		return 0;
+	}
+
+	psf_key_t *psfKey = &d->keyLookup[key];
+	if (psfKey->valueType != kPSF_Int32) {
+		// Not an Int32 key.
+		return 0;
+	}
+
+	uint32_t value = 0;
+	if (d->file->seekAndRead(d->fileHeader.dataOffset + psfKey->dataOffset, &value, sizeof(uint32_t)) !=
+		sizeof(uint32_t)) {
+		// Failed to read the value.
+		return 0;
+	}
+
+#if SYS_BYTEORDER == SYS_BIG_ENDIAN
+	// Byteswap the value
+	value = le32_to_cpu(value);
+#endif
+
+	d->cachedIntValues[key] = value;
+
+	return value;
+}
+
+/**
+ * Get the name of the system the loaded ROM is designed for.
+ * @param type System name type. (See the SystemName enum.)
+ * @return System name, or nullptr if type is invalid.
+ */
+const char *ParamSFO::systemName(unsigned int type) const
+{
+	RP_D(const ParamSFO);
+
+	static_assert(SYSNAME_TYPE_MASK == 3, "ParamSFO::systemName() array index optimization needs to be updated.");
+
+	static const char *const sysNames[4] = {"Sony PlayStation PARAM.SFO", "PARAM.SFO", "SFO", nullptr};
+
+	return sysNames[type & SYSNAME_TYPE_MASK];
+}
+
+/**
+ * Load field data.
+ * Called by RomData::fields() if the field data hasn't been loaded yet.
+ * @return 0 on success; negative POSIX error code on error.
+ */
+int ParamSFO::loadFieldData(void)
+{
+	RP_D(ParamSFO);
+	if (!d->fields.empty()) {
+		// Field data *has* been loaded...
+		return 0;
+	} else if (!d->file) {
+		// File isn't open.
+		return -EBADF;
+	} else if (!d->isValid) {
+		// Unknown ROM image type.
+		return -EIO;
+	}
+
+	// Add a tab with a list of entries in the SFO file.
+	// (Most of this taken from EXE_PE.cpp)
+	d->fields.addTab("SFO");
+	d->fields.reserve(1);
+	{
+		// Generate list data
+		auto *const vv_data = new RomFields::ListData_t();
+		vv_data->reserve(d->keys.size());
+		for (auto &key : d->keyLookup) {
+			vv_data->push_back(vector<string>());
+			auto &row = vv_data->back();
+			row.reserve(2);
+			row.push_back(key.first);
+
+			SFOValueType valueType = getKeyValueType(key.first);
+			if (valueType == SFOValueType::UTF8) {
+				row.push_back(getStringValue(key.first));
+			} else if (valueType == SFOValueType::Int32) {
+				row.push_back(fmt::format("0x{0:08X}", getIntValue(key.first)));
+			} else {
+				// Unknown value type?
+				row.push_back(string());
+			}
+		}
+
+		static const array<const char *, 2> field_names = {{
+			NOP_C_("SFO", "Key"),
+			NOP_C_("SFO", "Value"),
+		}};
+		vector<string> *const v_field_names = RomFields::strArrayToVector_i18n("SFO", field_names);
+
+		RomFields::AFLD_PARAMS params;
+		params.flags = RomFields::RFT_LISTDATA_SEPARATE_ROW;
+		params.headers = v_field_names;
+		params.data.single = vv_data;
+		params.col_attrs.align_data = AFLD_ALIGN2(TXA_D, TXA_D);
+		params.col_attrs.sorting = AFLD_ALIGN2(COLSORT_NC, COLSORT_NC);
+		params.col_attrs.sort_col = 0; // Name
+		params.col_attrs.sort_dir = RomFields::COLSORTORDER_ASCENDING;
+		d->fields.addField_listData(C_("SFO", "Values"), &params);
+	}
+
+	return 0;
+}
+
+} //namespace LibRomData

--- a/src/libromdata/Common/ParamSFO.hpp
+++ b/src/libromdata/Common/ParamSFO.hpp
@@ -1,0 +1,31 @@
+/***************************************************************************
+ * ROM Properties Page shell extension. (libromdata)                       *
+ * ParamSFO.hpp: PlayStation PARAM.SFO / PSF reader                        *
+ *                                                                         *
+ * Copyright (c) 2016-2026 by David Korth.                                 *
+ * Copyright (c) 2026 by Emma / InvoxiPlayGames.                           *
+ * SPDX-License-Identifier: GPL-2.0-or-later                               *
+ ***************************************************************************/
+
+#pragma once
+
+#include "librpbase/RomData.hpp"
+
+namespace LibRomData {
+
+ROMDATA_DECL_BEGIN(ParamSFO)
+
+public:
+	enum class SFOValueType {
+		None,
+		UTF8,
+		Int32
+	};
+	SFOValueType getKeyValueType(std::string key);
+
+	const std::string getStringValue(std::string key);
+	uint32_t getIntValue(std::string key);
+
+ROMDATA_DECL_END()
+
+} //namespace LibRomData

--- a/src/libromdata/Common/paramsfo_structs.h
+++ b/src/libromdata/Common/paramsfo_structs.h
@@ -1,0 +1,46 @@
+/***************************************************************************
+ * ROM Properties Page shell extension. (libromdata)                       *
+ * paramsfo_structs.h: PlayStation PARAM.SFO / PSF file data structures    *
+ *                                                                         *
+ * Copyright (c) 2016-2026 by David Korth.                                 *
+ * Copyright (c) 2026 by Emma / InvoxiPlayGames.                           *
+ * SPDX-License-Identifier: GPL-2.0-or-later                               *
+ ***************************************************************************/
+
+#pragma once
+
+#include <stdint.h>
+#include "common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct _psf_header {
+	uint32_t magic;
+	uint32_t version;
+	uint32_t keyOffset;
+	uint32_t dataOffset;
+	int numKeys;
+} psf_header_t;
+ASSERT_STRUCT(psf_header_t, 0x14);
+#define PSF_MAGIC	0x00505346 // '\0PSF'
+#define PSF_VERSION 0x01010000 // v1.1
+
+typedef enum _psf_type {
+	kPSF_UTF8 = 0x0204,
+	kPSF_Int32 = 0x0404,
+} psf_type_e;
+
+typedef struct _psf_key {
+	uint16_t keyNameOffset;
+	uint16_t valueType;
+	int dataLength;
+	int dataMax;
+	uint32_t dataOffset;
+} psf_key_t;
+ASSERT_STRUCT(psf_key_t, 0x10);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/libromdata/Handheld/PSP.cpp
+++ b/src/libromdata/Handheld/PSP.cpp
@@ -24,6 +24,7 @@ using namespace LibRpTexture;
 #include "disc/PartitionFile.hpp"
 
 // Other RomData subclasses
+#include "Common/ParamSFO.hpp"
 #include "Media/ISO.hpp"
 #include "Other/ELF.hpp"
 
@@ -86,11 +87,20 @@ public:
 	// Boot executable (EBOOT.BIN)
 	RomDataPtr bootExeData;
 
+	// PARAM.SFO
+	std::shared_ptr<ParamSFO> paramSfoData;
+
 	/**
 	 * Open the boot executable.
 	 * @return RomData* on success; nullptr on error.
 	 */
 	RomDataPtr openBootExe(void);
+
+	/**
+	 * Open the PARAM.SFO
+	 * @return RomData* on success; nullptr on error.
+	 */
+	std::shared_ptr<ParamSFO> openParamSfo(void);
 
 public:
 	/**
@@ -246,6 +256,42 @@ RomDataPtr PSPPrivate::openBootExe(void)
 	}
 
 	// Unable to open the default executable.
+	return nullptr;
+}
+
+/**
+ * Open the PARAM.SFO.
+ * @return RomData* on success; nullptr on error.
+ */
+std::shared_ptr<ParamSFO> PSPPrivate::openParamSfo(void)
+{
+	// FIXME: Returning `const RomDataPtr &` would be better,
+	// but the compiler is complaining that the nullptrs end up
+	// returning a reference to a local temporary object.
+
+	if (paramSfoData) {
+		// The PARAM.SFO is already open.
+		return paramSfoData;
+	}
+
+	if (!isoPartition || !isoPartition->isOpen()) {
+		// ISO partition is not open.
+		return nullptr;
+	}
+
+	// Open the PARAM.SFO
+	// TODO: Do video UMDs have PARAM.SFO?
+	const IRpFilePtr f_paramFile(isoPartition->open("/PSP_GAME/PARAM.SFO"));
+	if (f_paramFile) {
+		std::shared_ptr<ParamSFO> sfoData = std::make_shared<ParamSFO>(f_paramFile);
+		if (sfoData->isOpen() && sfoData->isValid()) {
+			// Boot executable is open and valid.
+			paramSfoData = sfoData;
+			return sfoData;
+		}
+	}
+
+	// Unable to open the PARAM.SFO
 	return nullptr;
 }
 
@@ -555,7 +601,34 @@ int PSP::loadFieldData(void)
 		d->fields.addField_string(gameID_title, s_gameID);
 	}
 
-	// TODO: Add fields from PARAM.SFO.
+	// Get metadata from the PARAM.SFO.
+	const std::shared_ptr<ParamSFO> paramSfo = const_cast<PSPPrivate *>(d)->openParamSfo();
+	if (paramSfo) {
+		// Add game-specific metadata.
+		if (d->discType == PSPPrivate::DiscType::PspGame)
+		{
+			if (paramSfo->getKeyValueType("TITLE") == ParamSFO::SFOValueType::UTF8) {
+				d->fields.addField_string(
+					C_("RomData", "Title"), paramSfo->getStringValue("TITLE"));
+			}
+			// TODO: localised languages
+
+			if (paramSfo->getKeyValueType("APP_VER") == ParamSFO::SFOValueType::UTF8) {
+				d->fields.addField_string(
+					C_("RomData", "Version"), paramSfo->getStringValue("APP_VER"));
+			}
+
+			if (paramSfo->getKeyValueType("PSP_SYSTEM_VER") == ParamSFO::SFOValueType::UTF8) {
+				d->fields.addField_string(C_("PSP", "OS Version"), paramSfo->getStringValue("PSP_SYSTEM_VER"));
+			}
+		}
+
+		// Add a PARAM.SFO tab.
+		const RomFields *const sfoFields = paramSfo->fields();
+		if (sfoFields) {
+			d->fields.addFields_romFields(paramSfo->fields(), RomFields::TabOffset_AddTabs);
+		}
+	}
 
 	// Show a tab for the boot file.
 	RomDataPtr bootExeData = d->openBootExe();
@@ -684,9 +757,17 @@ int PSP::loadMetaData(void)
 	// - Field 2: Revision?
 	// - Field 3: Age rating?
 
-	// NOTE: Using the game ID for titles...
 	const string s_gameID = d->getGameID();
-	d->metaData.addMetaData_string(Property::Title, s_gameID);
+
+	// Try to get title from the PARAM.SFO
+	const std::shared_ptr<ParamSFO> paramSfo = const_cast<PSPPrivate *>(d)->openParamSfo();
+	if (paramSfo && paramSfo->getKeyValueType("TITLE") == ParamSFO::SFOValueType::UTF8) {
+		const string s_gameTitle = paramSfo->getStringValue("TITLE");
+		d->metaData.addMetaData_string(Property::Title, s_gameTitle);
+	} else {
+		// fall back to using the Game ID for a title
+		d->metaData.addMetaData_string(Property::Title, s_gameID);
+	}
 
 	// TODO: More PSP-specific metadata?
 

--- a/src/libromdata/RomDataFactory.cpp
+++ b/src/libromdata/RomDataFactory.cpp
@@ -101,6 +101,9 @@ using std::unordered_set;
 #include "Handheld/VirtualBoy.hpp"
 #include "Handheld/WonderSwan.hpp"
 
+// RomData subclasses: Common
+#include "Common/ParamSFO.hpp"
+
 // RomData subclasses: Audio
 #include "Audio/ADX.hpp"
 #include "Audio/BCSTM.hpp"
@@ -319,7 +322,7 @@ static const array<RomDataFns, romDataFns_magic_count> romDataFns_magic = {{
  * Headers with addresses other than 0 should be
  * placed at the end of this array.
  */
-static const array<RomDataFns, 39> romDataFns_header = {{
+static const array<RomDataFns, 40> romDataFns_header = {{
 	// Consoles
 	GetRomDataFns(ColecoVision, ATTR_HAS_METADATA),
 	GetRomDataFns(Dreamcast, ATTR_HAS_THUMBNAIL | ATTR_HAS_METADATA | ATTR_SUPPORTS_DEVICES),
@@ -344,6 +347,9 @@ static const array<RomDataFns, 39> romDataFns_header = {{
 	GetRomDataFns(J2ME, ATTR_HAS_METADATA),	// .jad only; .jar is handled separately
 	GetRomDataFns(Nintendo3DS, ATTR_HAS_THUMBNAIL | ATTR_HAS_DPOVERLAY | ATTR_HAS_METADATA),
 	GetRomDataFns(PalmOS, ATTR_HAS_THUMBNAIL | ATTR_HAS_METADATA),	// TODO: Magic at 0x40?
+
+	// Common
+	GetRomDataFns(ParamSFO, ATTR_NONE),
 
 	// Audio
 	GetRomDataFns(ADX, ATTR_HAS_METADATA),


### PR DESCRIPTION
Supports reading PARAM.SFO files standalone, adds some metadata from PARAM.SFO to the existing PSP ISO reader.