### PR TITLE
NES: fix multiplier in PRG-/CHR-ROM size calculation

### DIFF
--- a/src/libromdata/Console/NES.cpp
+++ b/src/libromdata/Console/NES.cpp
@@ -346,7 +346,7 @@ unsigned int NESPrivate::get_prg_rom_size(void) const
 					prg_rom_size = 0xFFFFFFFF;
 				} else {
 					prg_rom_size = (1U << (header.ines.prg_banks >> 2)) *
-					               ((header.ines.prg_banks & 0x03) + 1);
+					               (((header.ines.prg_banks & 0x03) * 2) + 1);
 				}
 			}
 			break;
@@ -395,7 +395,7 @@ unsigned int NESPrivate::get_chr_rom_size(void) const
 					chr_rom_size = 0xFFFFFFFF;
 				} else {
 					chr_rom_size = (1U << (header.ines.chr_banks >> 2)) *
-					               ((header.ines.chr_banks & 0x03) + 1);
+					               (((header.ines.chr_banks & 0x03) * 2) + 1);
 				}
 			}
 			break;
@@ -971,7 +971,7 @@ int NES::isRomSupported_static(const DetectInfo *info)
 						prg_rom_size = 0xFFFFFFFF;
 					} else {
 						prg_rom_size = (1U << (inesHeader->prg_banks >> 2)) *
-						               ((inesHeader->prg_banks & 0x03) + 1);
+						               (((inesHeader->prg_banks & 0x03) * 2) + 1);
 					}
 				}
 				chr_rom_size = ((inesHeader->chr_banks |


### PR DESCRIPTION
The multiplier value should be multiplied by 2, as per NES 2.0 spec. Not a problem with the only officially licensed 8K game, Galaxian (since `0 * 2 == 0`), but would've affected any homebrew using non-standard sizes.

Also, I noticed that the CHR-ROM size calculation later in the code does not check for exponent-multiplier notation, which should probably be changed, but I didn't in this PR.