### PR TITLE
[libromdata] Add support for PDB Codeview info in PE binaries

### DIFF
--- a/src/libromdata/Other/EXE_PE.cpp
+++ b/src/libromdata/Other/EXE_PE.cpp
@@ -843,6 +843,7 @@ void EXEPrivate::addFields_PE(void)
 		addFields_PE_Export();
 		addFields_PE_Import();
 	}
+	addFields_PE_PDB();
 }
 
 /**
@@ -1317,6 +1318,109 @@ int EXEPrivate::addFields_PE_Import(void)
 	params.col_attrs.sort_dir   = RomFields::COLSORTORDER_ASCENDING;
 	fields.addField_listData(C_("EXE", "Imports"), &params);
 	return 0;
+}
+
+
+int EXEPrivate::addFields_PE_PDB(void) {
+	if (1) {
+		if (!std::holds_alternative<PE_data_t>(EXE_data)) {
+			// Not a PE executable.
+			return -EBADF;
+		}
+		PE_data_t &PE_data = std::get<PE_data_t>(EXE_data);
+		constexpr uintptr_t win32_maxpath = 260; // max path define on windows, should be this for all dos like paths (iirc nt paths are like 64k, but for pdbs this shooould be enough)
+		IMAGE_DATA_DIRECTORY debug_dir = [&]() -> IMAGE_DATA_DIRECTORY {
+			if (exeType == ExeType::PE) {
+				const auto &opthdr = hdr.pe.OptionalHeader.opt32;
+				return opthdr.DataDirectory[IMAGE_DATA_DIRECTORY_DEBUG_INFO];
+				
+			} else /*if (exeType == ExeType::PE32PLUS)*/ {
+				const auto &opthdr = hdr.pe.OptionalHeader.opt64;
+				return opthdr.DataDirectory[IMAGE_DATA_DIRECTORY_DEBUG_INFO];
+			}
+			return {}; // meow shouldnt run here but in that case the next check should fail as size and va are zeroed
+		}();
+
+		auto safe_read_vmem = [&](uint32_t va, uint32_t size, void* to) {
+			if (file && file->isOpen()){
+				auto addr = pe_vaddr_to_paddr(va,size);
+				file->seek(addr);
+				if (addr && file->read(to,size) == size) {
+					return true;
+				}
+			}
+			return false;
+		};
+
+		auto size = le32_to_cpu(debug_dir.Size);
+		if (size && debug_dir.VirtualAddress && (size/sizeof(IMAGE_DEBUG_DIRECTORY)) < 16) { // cap to a reasonable limit
+			vector<IMAGE_DEBUG_DIRECTORY> debug_ents( size/sizeof(IMAGE_DEBUG_DIRECTORY), {} );
+			if (safe_read_vmem(le32_to_cpu(debug_dir.VirtualAddress), size, debug_ents.data())) {
+				// oki we read all of them safely in
+				bool found_cv = false;
+				for (const auto& dir : debug_ents) {
+					if (le32_to_cpu(dir.Type) == IMAGE_DEBUG_TYPE_CODEVIEW && le32_to_cpu(dir.SizeOfData) <=  sizeof(CODEVIEW_INFO_PDB70) + win32_maxpath) { // sane bounds, cv data +  path + whatever-they-might-add-in-the-future
+						// aand we have a proper codeview entry
+						if (found_cv) {
+							// well, this is akward
+							return -EALREADY;
+						}
+						found_cv = true;
+
+						fields.addTab("PDB");
+						auto cv_timestamp = le32_to_cpu(dir.TimeDateStamp);
+						if (cv_timestamp != 0) {
+							fields.addField_dateTime("CodeView timestamp",
+								static_cast<time_t>(cv_timestamp),
+								RomFields::RFT_DATETIME_HAS_DATE |
+								RomFields::RFT_DATETIME_HAS_TIME);
+						} 
+
+
+
+						CODEVIEW_INFO_PDB70 cv {};
+						if (safe_read_vmem(le32_to_cpu(dir.AddressOfRawData), sizeof(CODEVIEW_INFO_PDB70),&cv)){
+							auto symsrv_path = fmt::format(
+								"{:08X}{:04X}{:04X}"
+								"{:02X}{:02X}{:02X}{:02X}"
+								"{:02X}{:02X}{:02X}{:02X}"
+								"{}",
+								le32_to_cpu(cv.PdbGuid.Data1),
+								le16_to_cpu(cv.PdbGuid.Data2),
+								le16_to_cpu(cv.PdbGuid.Data3),
+								cv.PdbGuid.Data4[0], cv.PdbGuid.Data4[1],
+								cv.PdbGuid.Data4[2], cv.PdbGuid.Data4[3],
+								cv.PdbGuid.Data4[4], cv.PdbGuid.Data4[5],
+								cv.PdbGuid.Data4[6], cv.PdbGuid.Data4[7],
+								le32_to_cpu(cv.PdbAge));
+							fields.addField_string("Symbol Server ID:", symsrv_path);
+							
+							std::array<char, win32_maxpath> pdb_path {};
+							uint32_t str_addie = le32_to_cpu(dir.AddressOfRawData) + offsetof(CODEVIEW_INFO_PDB70, ImageName);
+							uint32_t strlen_chars = le32_to_cpu(dir.SizeOfData) - offsetof(CODEVIEW_INFO_PDB70, ImageName) - 1; // - 1, null term, we ensure it ourselves
+							auto path_buf = std::make_unique<char[]>(strlen_chars + 1);
+							if (safe_read_vmem(str_addie, strlen_chars, &path_buf[0])) {
+								path_buf[strlen_chars] = '\0'; // ensure nullterm
+								fields.addField_string("PDB Path", &path_buf[0]);
+								char* last_path_component = &path_buf[0];
+								for (auto* cur = &path_buf[strlen_chars]; cur != &path_buf[0]; cur--) {
+									if (*cur == '\\'){
+										last_path_component = cur + 1;
+										break;
+									}
+								}				
+								fields.addField_string("PDB Link", fmt::format("<a href=\"https://msdl.microsoft.com/download/symbols/{}/{}/{}\">Microsoft Symbol Server</a>", last_path_component, symsrv_path, last_path_component));
+								return 0;
+							}
+							// not fatal, though some information is missing
+							return 0;
+						}
+					}
+				}
+			}
+		}
+	}
+	return -EFAULT;
 }
 
 /**

--- a/src/libromdata/Other/EXE_PE.cpp
+++ b/src/libromdata/Other/EXE_PE.cpp
@@ -1354,7 +1354,7 @@ int EXEPrivate::addFields_PE_PDB(void) {
 
 		auto size = le32_to_cpu(debug_dir.Size);
 		if (size && debug_dir.VirtualAddress && (size/sizeof(IMAGE_DEBUG_DIRECTORY)) < 16) { // cap to a reasonable limit
-			vector<IMAGE_DEBUG_DIRECTORY> debug_ents( size/sizeof(IMAGE_DEBUG_DIRECTORY), {} );
+			vector<IMAGE_DEBUG_DIRECTORY> debug_ents( size/sizeof(IMAGE_DEBUG_DIRECTORY) );
 			if (safe_read_vmem(le32_to_cpu(debug_dir.VirtualAddress), size, debug_ents.data())) {
 				// oki we read all of them safely in
 				bool found_cv = false;

--- a/src/libromdata/Other/EXE_p.hpp
+++ b/src/libromdata/Other/EXE_p.hpp
@@ -401,6 +401,13 @@ public:
 	 */
 	int addFields_PE_Import(void);
 
+	/**
+	 * Add fields for PE Codeview PDB info data.
+	 * @return 0 on success; negative POSIX error code on error.
+	 */
+	int addFields_PE_PDB(void);
+
+
 private:
 	/**
 	 * Load the IMAGE_LOAD_CONFIG_DIRECTORY.

--- a/src/libromdata/Other/exe_pe_structs.h
+++ b/src/libromdata/Other/exe_pe_structs.h
@@ -528,6 +528,39 @@ typedef enum {
 	XP_VISUAL_STYLE_MANIFEST_RESOURCE_ID = 123,
 } PE_ManifestID;
 
+// - https://github.com/MaxKellermann/w32api/blob/440c229960e782831d01c6638661f1c40cadbeb5/include/winnt.h
+typedef struct _IMAGE_DEBUG_DIRECTORY {
+    uint32_t   Characteristics;
+    uint32_t   TimeDateStamp;
+    uint16_t   MajorVersion;
+    uint16_t   MinorVersion;
+    uint32_t   Type;
+    uint32_t   SizeOfData;
+    uint32_t   AddressOfRawData;
+    uint32_t   PointerToRawData;
+} IMAGE_DEBUG_DIRECTORY;
+ASSERT_STRUCT(_IMAGE_DEBUG_DIRECTORY, 6*sizeof(uint32_t) + 2*sizeof(uint16_t));
+
+#define IMAGE_DEBUG_TYPE_CODEVIEW 2
+
+typedef struct _GUID
+{
+	uint32_t Data1;
+    uint16_t Data2;
+    uint16_t Data3;
+    uint8_t Data4[8];
+} GUID;
+//https://github.com/winsiderss/systeminformer/blob/5bb68c3a978533680e782bff60abe9d979ca6b64/phlib/include/mapimg.h#L810
+typedef struct _CODEVIEW_INFO_PDB70
+{
+    uint32_t Signature;
+    GUID PdbGuid;
+    uint32_t PdbAge;
+	char ImageName[1];
+} CODEVIEW_INFO_PDB70;
+
+
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
implements support for codeview pdb information

currently waiting for linewrap and hyperlink flag support

<img width="405" height="522" alt="image" src="https://github.com/user-attachments/assets/1f2db756-4081-4226-b036-bda54b9f0473" />
<img width="405" height="561" alt="image" src="https://github.com/user-attachments/assets/66f2ced7-2cff-47d3-a342-46e85133e3d0" />
